### PR TITLE
chore: unify brand labels to "Twitter(X)"

### DIFF
--- a/src/app/(site)/about/page.test.tsx
+++ b/src/app/(site)/about/page.test.tsx
@@ -16,7 +16,7 @@ const fixture = {
   philosophy: undefined,
   love: ['dubstep', 'brostep'],
   skillGroups: [{ category: 'lang', items: ['TypeScript', 'Rust'] }],
-  contacts: [{ label: 'x', handle: '@naporin24690', href: 'https://x.com/naporin24690' }],
+  contacts: [{ label: 'Twitter(X)', handle: '@naporin24690', href: 'https://x.com/naporin24690' }],
 } satisfies Profile;
 
 describe('AboutPage', () => {

--- a/src/app/(site)/about/profile.ts
+++ b/src/app/(site)/about/profile.ts
@@ -56,8 +56,8 @@ export const profile = {
     { category: 'graphics', items: ['WebGPU', 'WGSL', 'Unity', 'UdonSharp'] },
   ],
   contacts: [
-    { label: 'x', handle: '@naporin24690', href: 'https://x.com/naporin24690' },
-    { label: 'github', handle: 'naporin0624', href: 'https://github.com/naporin0624' },
-    { label: 'mail', handle: 'contact@napochaan.com', href: 'mailto:contact@napochaan.com' },
+    { label: 'Twitter(X)', handle: '@naporin24690', href: 'https://x.com/naporin24690' },
+    { label: 'GitHub', handle: 'naporin0624', href: 'https://github.com/naporin0624' },
+    { label: 'Email', handle: 'contact@napochaan.com', href: 'mailto:contact@napochaan.com' },
   ],
 } as const;

--- a/src/app/(site)/colophon/content.ts
+++ b/src/app/(site)/colophon/content.ts
@@ -97,7 +97,7 @@ export const colophon = {
       { name: 'FeedLink', why: 'RSS フィードへのリンク。一覧ページの PageHeader 直下に置いて、購読を促す。' },
       {
         name: 'ShareBar',
-        why: '記事末尾の共有バー。X(Twitter)の web intent と、OS の共有シート（Web Share API、非対応環境ではクリップボードへコピー）を呼ぶ2アクション。Instagram は URL 共有導線が無いので置いてない。',
+        why: '記事末尾の共有バー。Twitter(X) の web intent と、OS の共有シート（Web Share API、非対応環境ではクリップボードへコピー）を呼ぶ2アクション。Instagram は URL 共有導線が無いので置いてない。',
       },
       {
         name: 'BackToIndex',

--- a/src/app/(site)/contact/page.test.tsx
+++ b/src/app/(site)/contact/page.test.tsx
@@ -33,6 +33,6 @@ describe('ContactPage', () => {
 
   it('renders the direct-contact links', async () => {
     render(await ContactPage());
-    await expect.element(page.getByRole('link', { name: /github/ })).toHaveAttribute('href', 'https://github.com/naporin0624');
+    await expect.element(page.getByRole('link', { name: /GitHub/ })).toHaveAttribute('href', 'https://github.com/naporin0624');
   });
 });


### PR DESCRIPTION
## 概要

user-facing のブランド表記を **「Twitter(X)」**（Twitter 先・X を括弧）に統一し、他の連絡先ラベルも表示形に揃える。

- `about` の連絡先: `x` / `github` / `mail` → `Twitter(X)` / `GitHub` / `Email`
- `colophon` の ShareBar 説明: `X(Twitter)` → `Twitter(X)`
- `about` ページテストの fixture ラベル: `x` → `Twitter(X)`

UI 側（`ShareBar` の "Twitter(X) ↗"、`QuoteShare` の "Twitter(X) で引用"）は既に正準形のため変更なし。

## スコープ外（意図的に据え置き）

- Next.js metadata の `twitter:` キー（OG/Twitter Card の API 契約・変更不可）
- `twitter.com/intent/tweet`（実際に叩く X の web intent エンドポイント）
- 内部識別子（`TwitterIcon` / `buildQuoteTweetUrl` / `tweet-intent`）

## テスト

- [x] about ページテスト green（2/2）
- [x] lint + typecheck clean（pre-commit hook 通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)