### PR TITLE
Fix: Keep gigs upcoming through their entire day

### DIFF
--- a/src/app/(site)/log/_lib/build-log-timeline/build-log-timeline.test.ts
+++ b/src/app/(site)/log/_lib/build-log-timeline/build-log-timeline.test.ts
@@ -160,4 +160,12 @@ describe('buildLogTimeline manual entries', () => {
     expect(items.find((item) => item.id === 'log-future')?.upcoming).toBe(true);
     expect(items.find((item) => item.id === 'log-past')?.upcoming).toBe(false);
   });
+
+  it('keeps a gig dated today upcoming until the day is over', () => {
+    // now is 2026-06-08T00:00:00Z → 2026-06-08 09:00 Asia/Tokyo, so the event day is today.
+    const logs: LogManualItem[] = [{ id: 'today', title: 'live today', date: '2026-06-08', meta: 'VJ' }];
+    const items = buildLogTimeline([], [], now, logs).find((g) => g.year === 2026)?.items ?? [];
+
+    expect(items.find((item) => item.id === 'log-today')?.upcoming).toBe(true);
+  });
 });

--- a/src/app/(site)/log/_lib/build-log-timeline/index.ts
+++ b/src/app/(site)/log/_lib/build-log-timeline/index.ts
@@ -66,8 +66,9 @@ const toWorkEntry = (work: WorkRow): SortableEntry => {
 };
 
 // Manual log entries are dated, so they sort alongside posts by sortDate.
-// A gig dated strictly after `now` (day precision, Asia/Tokyo) is `upcoming`, which
-// the timeline renders with a filled dot.
+// A gig whose day (day precision, Asia/Tokyo) is today or later is `upcoming`, which
+// the timeline renders with a filled dot. It only stops being upcoming once its day
+// has fully passed — an event stays upcoming through the whole of its own day.
 const toManualEntry = (item: LogManualItem, now: string): SortableEntry => {
   const at = dayjs(item.date).tz('Asia/Tokyo');
   const today = dayjs(now).tz('Asia/Tokyo');
@@ -78,7 +79,7 @@ const toManualEntry = (item: LogManualItem, now: string): SortableEntry => {
     date: at.format('MM.DD'),
     meta: item.meta,
     title: item.title,
-    upcoming: at.startOf('day').isAfter(today.startOf('day')),
+    upcoming: !at.startOf('day').isBefore(today.startOf('day')),
     href: item.url,
     sortDate: item.date,
   };


### PR DESCRIPTION
## Summary
Fixed the logic for determining when a gig transitions from "upcoming" to "past" status. Previously, gigs were only marked as upcoming if their date was strictly after today. Now they remain upcoming through the entire day they occur, only becoming past once that day has fully passed.

## Changes
- **Updated `toManualEntry` function**: Changed the `upcoming` flag calculation from `at.startOf('day').isAfter(today.startOf('day'))` to `!at.startOf('day').isBefore(today.startOf('day'))`. This ensures events dated today are marked as upcoming.
- **Updated documentation**: Clarified the comment explaining that events stay upcoming through the whole of their own day, not just after it.
- **Added test case**: Added `'keeps a gig dated today upcoming until the day is over'` test to verify that gigs dated today are correctly marked as upcoming.

## Implementation Details
The fix uses a logical inversion (`!isBefore`) instead of `isAfter` to include today's date in the upcoming range. This is semantically clearer: an event is upcoming if its day has not yet passed (i.e., it's not before today), rather than checking if it's strictly after today.

https://claude.ai/code/session_01NmVSgoPxsbAGYx1YxgpPHV