### PR TITLE
chore(payload): admin サイドバーをグループ化

### DIFF
--- a/src/collections/blog.ts
+++ b/src/collections/blog.ts
@@ -15,6 +15,7 @@ export const Blog = {
   labels: { singular: 'blog', plural: 'blogs' },
   defaultSort: '-publishedAt',
   admin: {
+    group: 'コンテンツ',
     useAsTitle: 'title',
     defaultColumns: ['title', 'thumbnail', 'publishedAt', '_status'],
   },

--- a/src/collections/gallery.ts
+++ b/src/collections/gallery.ts
@@ -17,6 +17,7 @@ export const Gallery = {
   // manual `order` number field is gone — drag the rows to reorder.
   orderable: true,
   admin: {
+    group: 'コンテンツ',
     useAsTitle: 'caption',
     defaultColumns: ['caption', 'homeTop', '_status'],
   },

--- a/src/collections/logs.ts
+++ b/src/collections/logs.ts
@@ -14,6 +14,7 @@ export const Logs = {
   labels: { singular: 'log', plural: 'logs' },
   defaultSort: '-date',
   admin: {
+    group: 'コンテンツ',
     useAsTitle: 'title',
     defaultColumns: ['title', 'date', 'meta', '_status'],
   },

--- a/src/collections/media.ts
+++ b/src/collections/media.ts
@@ -10,6 +10,9 @@ const revalidateMedia = (): void => revalidateTagsAndPaths([CACHE_TAGS.news, CAC
 export const Media: CollectionConfig = {
   slug: 'media',
   labels: { singular: 'media', plural: 'media' },
+  admin: {
+    group: 'システム',
+  },
   upload: {
     mimeTypes: ['image/*', 'application/pdf'],
   },

--- a/src/collections/news.ts
+++ b/src/collections/news.ts
@@ -21,6 +21,7 @@ export const News = {
   // `['-pinned', '-publishedAt']` sort in lib/payload/news).
   defaultSort: '-publishedAt',
   admin: {
+    group: 'コンテンツ',
     useAsTitle: 'title',
     // `title` must lead so the list row links to the edit view — Payload only
     // wraps the FIRST column in the doc link, and a leading checkbox column

--- a/src/collections/users.ts
+++ b/src/collections/users.ts
@@ -4,6 +4,7 @@ export const Users: CollectionConfig = {
   slug: 'users',
   labels: { singular: 'user', plural: 'users' },
   admin: {
+    group: 'システム',
     useAsTitle: 'email',
   },
   auth: {

--- a/src/collections/works.ts
+++ b/src/collections/works.ts
@@ -18,6 +18,7 @@ export const Works = {
   // explicit date sort (see lib/payload/works).
   defaultSort: '-date',
   admin: {
+    group: 'コンテンツ',
     useAsTitle: 'title',
     defaultColumns: ['date', 'thumbnail', 'title', 'type', 'body', '_status'],
   },

--- a/src/globals/profile.ts
+++ b/src/globals/profile.ts
@@ -8,6 +8,9 @@ import type { GlobalConfig } from 'payload';
 export const Profile = {
   slug: 'profile',
   label: 'profile',
+  admin: {
+    group: 'サイト設定',
+  },
   access: {
     read: () => true,
     update: ({ req: { user } }) => user !== null,


### PR DESCRIPTION
## 概要

Payload 管理画面のサイドバーが全コレクション・グローバルのフラットな羅列で見づらかったため、`admin.group` を付与して 3 グループに整理した。

## グループ構成

| グループ | 対象 |
| --- | --- |
| **コンテンツ** | News / Works / Blog / Gallery / Logs |
| **サイト設定** | Profile (global) |
| **システム** | Media / Users |

## 変更内容

- 既存の `admin` ブロックを持つコレクション（News / Works / Blog / Gallery / Logs / Users）は `group` を 1 行追加
- `admin` ブロックが無かった Media コレクションと Profile グローバルは `admin` ブロックを新設して `group` を追加
- 機能的変更なし（管理画面のナビ表示のみ）

## 確認

- `pnpm lint` ✅
- `pnpm typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)