### PR TITLE
Add day of week to date formatting in log timeline

### DIFF
--- a/src/app/(site)/log/_lib/build-log-timeline/build-log-timeline.test.ts
+++ b/src/app/(site)/log/_lib/build-log-timeline/build-log-timeline.test.ts
@@ -78,12 +78,12 @@ describe('buildLogTimeline', () => {
     expect(group?.items[0]?.href).toBe('https://sizu.me/x/posts/9');
   });
 
-  it('formats a post date as MM.DD and never marks it upcoming', () => {
+  it('formats a post date as MM.DD (ddd) in JST and never marks it upcoming', () => {
     const posts = [post({ id: '1', date: '2026-04-09T00:00:00.000Z', source: 'zenn' })];
 
     const [group] = buildLogTimeline([], posts, now);
 
-    expect(group?.items[0]?.date).toBe('04.09');
+    expect(group?.items[0]?.date).toBe('04.09 (Thu)');
     expect(group?.items[0]?.upcoming).toBe(false);
   });
 
@@ -100,12 +100,12 @@ describe('buildLogTimeline', () => {
 });
 
 describe('buildLogTimeline work date precision', () => {
-  it('shows MM.DD for a work that has a date', () => {
+  it('shows MM.DD (ddd) for a work that has a date', () => {
     const works = [work({ id: 'dated', year: 2025, date: '2025-03-15' })];
 
     const [group] = buildLogTimeline(works, [], now);
 
-    expect(group?.items[0]?.date).toBe('03.15');
+    expect(group?.items[0]?.date).toBe('03.15 (Sat)');
   });
 
   it('shows em dash for a work without a date', () => {
@@ -143,7 +143,7 @@ describe('buildLogTimeline manual entries', () => {
     const y2026 = groups.find((g) => g.year === 2026);
     expect(y2026).toBeDefined();
     const entry = y2026?.items.find((i) => i.id === 'log-1');
-    expect(entry).toMatchObject({ title: 'サイト公開', date: '06.01', meta: 'milestone', upcoming: false, href: 'https://napochaan.com' });
+    expect(entry).toMatchObject({ title: 'サイト公開', date: '06.01 (Mon)', meta: 'milestone', upcoming: false, href: 'https://napochaan.com' });
   });
 
   it('keeps working when no manual entries are passed (default param)', () => {

--- a/src/app/(site)/log/_lib/build-log-timeline/index.ts
+++ b/src/app/(site)/log/_lib/build-log-timeline/index.ts
@@ -38,7 +38,7 @@ const toPostEntry = (post: ExternalPost): SortableEntry => {
   return {
     id: `post-${post.id}`,
     year: at.year(),
-    date: at.format('MM.DD'),
+    date: at.format('MM.DD (ddd)'),
     meta: post.source,
     title: post.title,
     upcoming: false,
@@ -56,7 +56,7 @@ const toWorkEntry = (work: WorkRow): SortableEntry => {
   return {
     id: `work-${work.id}`,
     year: work.year,
-    date: at !== undefined ? at.format('MM.DD') : '—',
+    date: at !== undefined ? at.format('MM.DD (ddd)') : '—',
     meta: work.type,
     title: work.title,
     upcoming: false,
@@ -76,7 +76,7 @@ const toManualEntry = (item: LogManualItem, now: string): SortableEntry => {
   return {
     id: `log-${item.id}`,
     year: at.year(),
-    date: at.format('MM.DD'),
+    date: at.format('MM.DD (ddd)'),
     meta: item.meta,
     title: item.title,
     upcoming: !at.startOf('day').isBefore(today.startOf('day')),


### PR DESCRIPTION
## Summary
Updated date formatting across the log timeline to include the day of the week abbreviation (ddd) in JST timezone, changing from `MM.DD` to `MM.DD (ddd)` format.

## Changes
- **Post entries**: Updated date format to include day of week (e.g., `04.09 (Thu)`)
- **Work entries**: Updated date format to include day of week (e.g., `03.15 (Sat)`)
- **Manual log entries**: Updated date format to include day of week (e.g., `06.01 (Mon)`)
- **Test expectations**: Updated all test assertions to match the new date format with day of week abbreviations

## Implementation Details
- Modified three entry conversion functions in `src/app/(site)/log/_lib/build-log-timeline/index.ts`:
  - `toPostEntry()`: Changed format string from `'MM.DD'` to `'MM.DD (ddd)'`
  - `toWorkEntry()`: Changed format string from `'MM.DD'` to `'MM.DD (ddd)'`
  - `toManualEntry()`: Changed format string from `'MM.DD'` to `'MM.DD (ddd)'`
- Updated corresponding test cases to verify the new format is applied correctly across all entry types

https://claude.ai/code/session_01FWEnScBFwAYgH5qnh5Guk1