### PR TITLE
feat: 未マッチ URL を共通 404 ページに配線

### DIFF
--- a/docs/superpowers/plans/2026-07-02-global-not-found.md
+++ b/docs/superpowers/plans/2026-07-02-global-not-found.md
@@ -1,0 +1,126 @@
+# 共通 404 ページ配線 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 未マッチ URL(例 `/foobar`)で既存のスタイル済み 404(`(site)/not-found.tsx`)が表示されるよう、`(site)` に catch-all route を追加する。
+
+**Architecture:** multiple root layouts 構成((site)/(payload))のため root `not-found.tsx` は置けない。代わりに `(site)` 直下の catch-all `[...not-found]/page.tsx` が全未マッチ URL を受けて `notFound()` を throw し、既存の `(site)/not-found.tsx` boundary に委譲する。静的セグメント(`/admin`, `/api`, `robots.txt` 等)は dynamic より優先されるため既存ルートに影響しない。
+
+**Tech Stack:** Next.js 15.3.9 App Router / vitest (node env: `*.test.ts`) / tsgo typecheck / oxlint+oxfmt
+
+## Global Constraints
+
+- 関数は arrow function のみ(`const fn = () => {}`)
+- テストは実装に colocate する
+- `*.test.ts` は node 環境で走る(DOM 不要のテストは `.ts`)
+- 実装完了後は必ず `pnpm lint && pnpm typecheck` を通すこと
+- `(site)/not-found.tsx`・ErrorScreen・(payload) には触れない
+- Next 15.3.9 の `notFound()` は message=digest=`NEXT_HTTP_ERROR_FALLBACK;404` の Error を throw する
+
+---
+
+### Task 1: catch-all route(TDD)
+
+**Files:**
+
+- Create: `src/app/(site)/[...not-found]/page.tsx`
+- Test: `src/app/(site)/[...not-found]/page.test.ts`
+
+**Interfaces:**
+
+- Consumes: `notFound` from `next/navigation`
+- Produces: default export の Server Component(呼ぶと必ず notFound エラーを throw)。他タスクからの依存なし。
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/app/(site)/[...not-found]/page.test.ts
+import { describe, expect, it } from 'vitest';
+
+import CatchAllNotFound from './page';
+
+describe('CatchAllNotFound', () => {
+  it('throws the Next.js notFound error (digest NEXT_HTTP_ERROR_FALLBACK;404)', () => {
+    expect(() => CatchAllNotFound()).toThrowError('NEXT_HTTP_ERROR_FALLBACK;404');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run "src/app/(site)/[...not-found]/page.test.ts"`
+Expected: FAIL — `Failed to resolve import "./page"`(ファイル未作成)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// src/app/(site)/[...not-found]/page.tsx
+import { notFound } from 'next/navigation';
+
+const CatchAllNotFound = () => {
+  notFound();
+};
+
+export default CatchAllNotFound;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run "src/app/(site)/[...not-found]/page.test.ts"`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Lint & typecheck**
+
+Run: `pnpm lint && pnpm typecheck`
+Expected: どちらも exit 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "src/app/(site)/[...not-found]/page.tsx" "src/app/(site)/[...not-found]/page.test.ts"
+git commit -m "feat: route unmatched URLs to the shared 404 page via catch-all"
+```
+
+---
+
+### Task 2: 実挙動の検証(dev server)
+
+**Files:** 変更なし(検証のみ)
+
+**Interfaces:**
+
+- Consumes: Task 1 の catch-all route
+- Produces: なし(検証結果の報告のみ)
+
+- [ ] **Step 1: dev server をバックグラウンド起動**
+
+Run: `pnpm dev`(background, worktree 内)
+Expected: `Ready` ログ。※ port 3000 が使用中なら 3001 に自動フォールバックするので、以降の curl は実際の port を使う。
+
+- [ ] **Step 2: 未マッチ URL が styled 404 になることを確認**
+
+Run: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/this-page-does-not-exist`
+Expected: `404`
+
+Run: `curl -s http://localhost:3000/this-page-does-not-exist | grep -c "not found"`
+Expected: 1 以上(ErrorScreen の `// 404 — not found` kicker が HTML に含まれる)。Next デフォルト 404 の `This page could not be found` が **含まれない** ことも確認:
+`curl -s http://localhost:3000/this-page-does-not-exist | grep -c "This page could not be found"` → 0
+
+- [ ] **Step 3: 深いパス・既存ルートの無影響を確認**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/works/a/b/c   # 404
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/              # 200
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/works         # 200
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/robots.txt    # 200
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/admin         # 200 か 3xx(payload が処理していれば OK)
+```
+
+- [ ] **Step 4: dev server を停止**
+
+起動した background シェルを kill する(TaskStop / kill)。ユーザーの main repo の dev server ではないことを確認してから止めること。
+
+- [ ] **Step 5: 全テストスイートを実行**
+
+Run: `pnpm test`
+Expected: 既存 870+ 件 + 新規 1 件すべて PASS

--- a/docs/superpowers/specs/2026-07-02-global-not-found-design.md
+++ b/docs/superpowers/specs/2026-07-02-global-not-found-design.md
@@ -1,0 +1,59 @@
+# 共通 404 ページ配線 — Design
+
+Date: 2026-07-02
+Status: Approved
+
+## 問題
+
+未マッチ URL(例: `https://napochaan.com/this-page-does-not-exist`)が Next.js 組み込みの無地
+「404 This page could not be found」で表示される。
+
+原因: このプロジェクトは `(site)` / `(payload)` の 2 つの route group がそれぞれ root layout を持つ
+multiple root layouts 構成。`src/app/` 直下に `layout.tsx` が存在しないため、グローバルな
+`app/not-found.tsx` を置けない。既存のスタイル済み 404(`src/app/(site)/not-found.tsx`,
+ErrorScreen ベース)は `(site)` 内のページが `notFound()` を呼んだ時(存在しない blog slug 等)
+のみ使われ、ルーティング自体が未マッチの URL には届かない。
+
+## 解決策
+
+`(site)` 直下に catch-all route を 1 つ追加し、`notFound()` を呼ぶ。
+
+```
+src/app/(site)/[...not-found]/
+├── page.tsx                 # notFound() を呼ぶだけの Server Component
+└── page.test.ts             # default export が NEXT_HTTP_ERROR_FALLBACK;404 を throw することを確認
+```
+
+- どのルートにもマッチしない URL(全深度: `/foobar`, `/works/a/b` など)がこの catch-all に
+  マッチし、`notFound()` により既存の `(site)/not-found.tsx` が SiteShell 内・HTTP 404 で表示される。
+
+## 検討した代替案
+
+1. **catch-all route(採用)** — 1 ファイル追加。multiple root layouts 構成での定石。
+2. root layout を単一化して `app/not-found.tsx` を置く — (payload) と (site) の `<html>` が
+   別物なので大規模リストラになる。過剰。
+3. `global-not-found.tsx`(experimental) — Next.js 15.4+ の実験機能。現行 15.3.9 では使えない。
+
+## 影響範囲・安全性
+
+- **既存ルートへの影響なし**: Next.js は静的セグメントを dynamic セグメントより優先してマッチする。
+  `/admin/*`・`/api/*`((payload) 側)、`robots.txt`・`sitemap.xml`・`llms.txt`・`/next/*`、
+  `(home)` の `/` はすべて catch-all より先に解決される。
+- **メタデータ**: 404 レンダリングには Next.js が自動で `noindex` を付与する。追加対応不要。
+- **エラーハンドリング**: 既存の `error.tsx` / `global-error.tsx` は変更しない。
+- **ISR/OpenNext**: catch-all は動的レンダリング。現状の組み込み 404 も worker で SSR されて
+  いるため、負荷特性は変わらない。
+
+## テスト
+
+- `page.test.ts`(node 環境): default export を呼ぶと `notFound()` 由来のエラーが throw される
+  ことを assert。
+- 手動確認: dev server で `/this-page-does-not-exist` にアクセスし、ErrorScreen 404 と
+  HTTP 404 status を確認。既存ルート(`/`, `/works`, `/admin`, `/robots.txt`)が影響を
+  受けないことも確認。
+
+## 変更しないもの
+
+- `src/app/(site)/not-found.tsx`(既存 404 の見た目・文言)
+- ErrorScreen コンポーネント
+- (payload) route group

--- a/src/app/(site)/[...not-found]/page.test.ts
+++ b/src/app/(site)/[...not-found]/page.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import CatchAllNotFound from './page';
+
+describe('CatchAllNotFound', () => {
+  it('throws the Next.js notFound error (digest NEXT_HTTP_ERROR_FALLBACK;404)', () => {
+    expect(() => CatchAllNotFound()).toThrowError('NEXT_HTTP_ERROR_FALLBACK;404');
+  });
+});

--- a/src/app/(site)/[...not-found]/page.tsx
+++ b/src/app/(site)/[...not-found]/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation';
+
+const CatchAllNotFound = () => {
+  notFound();
+};
+
+export default CatchAllNotFound;


### PR DESCRIPTION
## 概要

未マッチ URL(例: `/this-page-does-not-exist`)が Next.js 組み込みの無地 404「This page could not be found」で表示される問題を修正します。

このリポジトリは `(site)` / `(payload)` の 2 つの route group がそれぞれ root layout を持つ構成のため、`app/` 直下にグローバルな `not-found.tsx` を置けません。既存のスタイル済み 404(`(site)/not-found.tsx`, ErrorScreen)は `(site)` 内で `notFound()` が呼ばれた時(存在しない blog slug 等)しか使われず、ルーティング未マッチの URL には届いていませんでした。

## 変更内容

- `src/app/(site)/[...not-found]/page.tsx` — `notFound()` を呼ぶだけの catch-all route を追加。全深度の未マッチ URL がここにマッチし、既存の styled 404 が SiteShell 内・HTTP 404 で表示されます
- `src/app/(site)/[...not-found]/page.test.ts` — notFound エラー(digest `NEXT_HTTP_ERROR_FALLBACK;404`)を throw することを検証する unit test
- 設計 spec / 実装 plan(`docs/superpowers/`)

## 既存ルートへの影響

なし。Next.js は静的セグメントを dynamic セグメントより優先するため、`/admin`・`/api`(payload)、`robots.txt`・`sitemap.xml`・`llms.txt`、`(home)` の `/` はすべて catch-all より先に解決されます。404 レンダリングには Next が自動で `noindex` を付与します。

## テスト

- [x] 新規 unit test PASS(node env)
- [x] 全テストスイート 871 passed / 1 skipped
- [x] `pnpm lint` / `pnpm typecheck` PASS
- [x] production build(`pnpm build` + `next start` :3001)での実挙動検証 — 詳細は下のコメント参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)
