### PR TITLE
fix: /logs → /log 恒久リダイレクト + admin 日付 UI の日本語化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,16 @@ const nextConfig: NextConfig = {
     staleTimes: { static: 0, dynamic: 0 },
   },
   serverExternalPackages: ['drizzle-kit', 'esbuild', 'esbuild-register'],
+  redirects: async () => [
+    // The public route is /log (the CMS collection slug is `logs`, so /logs is a
+    // natural guess). `:path*` matches zero or more segments, so this covers
+    // both /logs and nested paths like /logs/rss.xml with a 308.
+    {
+      source: '/logs/:path*',
+      destination: '/log/:path*',
+      permanent: true,
+    },
+  ],
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@payloadcms/plugin-seo": "3.84.1",
     "@payloadcms/richtext-lexical": "3.84.1",
     "@payloadcms/storage-r2": "3.84.1",
+    "@payloadcms/translations": "3.84.1",
     "@radix-ui/react-slot": "^1.2.4",
     "budoux": "^0.8.4",
     "dayjs": "^1.11.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@payloadcms/storage-r2':
         specifier: 3.84.1
         version: 3.84.1(@types/react@19.2.16)(monaco-editor@0.55.1)(next@15.3.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(payload@3.84.1(graphql@16.14.1)(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
+      '@payloadcms/translations':
+        specifier: 3.84.1
+        version: 3.84.1
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.16)(react@19.2.7)

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -6,6 +6,7 @@ import { sqliteD1Adapter } from '@payloadcms/db-d1-sqlite';
 import { seoPlugin } from '@payloadcms/plugin-seo';
 import { BlocksFeature, lexicalEditor } from '@payloadcms/richtext-lexical';
 import { r2Storage } from '@payloadcms/storage-r2';
+import { ja } from '@payloadcms/translations/languages/ja';
 import { buildConfig } from 'payload';
 
 import { ImageRow } from './blocks/image-row';
@@ -99,6 +100,10 @@ const serverURL = process.env.BASE_URL ?? 'http://localhost:3000';
 
 export default buildConfig({
   i18n: {
+    // Restricting supportedLanguages to ja pins the admin UI language regardless
+    // of browser detection, which is what makes the date picker load the
+    // date-fns ja locale (month/weekday names in the calendar).
+    supportedLanguages: { ja },
     fallbackLanguage: 'ja',
   },
   admin: {


### PR DESCRIPTION
## Summary

- **`/logs` → `/log` 恒久リダイレクト (308)**: `next.config.ts` の `redirects()` に `source: '/logs/:path*' → destination: '/log/:path*'`(`permanent: true`)を追加。`:path*` は 0 個以上のセグメントにマッチするため、`/logs` 本体と `/logs/rss.xml` のような下層 URL を 1 ルールでカバーする。OpenNext は `routes-manifest.json` の redirects を routing layer で処理するので Cloudflare Workers 上でも有効([docs](https://opennext.js.org/aws/inner_workings/routing))。
- **Payload admin の calendar / date picker を日本語化**: `i18n.fallbackLanguage: 'ja'` だけでは `supportedLanguages` が全言語デフォルトのままで、ブラウザ言語検出により en に解決されると date picker の暦(月名・曜日)が英語表示になっていた。`supportedLanguages: { ja }` で日本語に固定し、date-fns の ja ロケールが確実に読み込まれるようにした。
- 直接 import する `@payloadcms/translations` を `package.json` に明示追加(shamefully-hoist 頼みの phantom dependency 回避)。

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` グリーン
- [ ] `pnpm dev` 再起動後、`/logs` と `/logs/rss.xml` が 308 で `/log` 系に転送されること
- [ ] `/admin` の日付フィールドで暦の月・曜日が日本語表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)