### PR TITLE
fix: /logs リダイレクトが OpenNext 上で literal `:path*` に飛ぶ問題を修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,11 +17,18 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['drizzle-kit', 'esbuild', 'esbuild-register'],
   redirects: async () => [
     // The public route is /log (the CMS collection slug is `logs`, so /logs is a
-    // natural guess). `:path*` matches zero or more segments, so this covers
-    // both /logs and nested paths like /logs/rss.xml with a 308.
+    // natural guess). Kept as two rules instead of one `/logs/:path*`: OpenNext's
+    // routing layer only compiles the destination when the source match produced
+    // params, so a zero-segment `:path*` match leaves the literal ":path*" in the
+    // Location header. Exact + `:path+` (one or more segments) avoids that case.
     {
-      source: '/logs/:path*',
-      destination: '/log/:path*',
+      source: '/logs',
+      destination: '/log',
+      permanent: true,
+    },
+    {
+      source: '/logs/:path+',
+      destination: '/log/:path+',
       permanent: true,
     },
   ],


### PR DESCRIPTION
## Summary

PR #15 の `/logs/:path*` → `/log/:path*` リダイレクトが、staging で `/logs` アクセス時に **literal の `https://stg.napochaan.com/log/:path*` へ転送される**バグの修正。

### 原因(OpenNext routing layer の挙動)

`@opennextjs/aws` の `handleRewrites`(redirects も同経路)は、source のマッチで **params が 1 つ以上得られたときだけ** destination をコンパイルする(`core/routing/matcher.js` の `isUsingParams` ガード)。`/logs` は `/logs/:path*` に 0 セグメントでマッチし、path-to-regexp 6.3.0 が params を `{}` で返すため、destination が未コンパイルのまま literal `/log/:path*` として Location に入る。

OpenNext が使う path-to-regexp 6.3.0 で置換ロジックを抜き出して再現検証済み:

| source | リクエスト | params | Location |
|---|---|---|---|
| `/logs/:path*` | `/logs` | `{}` | `/log/:path*` ❌ |
| `/logs/:path*` | `/logs/rss.xml` | `{path:["rss.xml"]}` | `/log/rss.xml` ✅ |
| `/logs`(exact) | `/logs` | `{}`(placeholder なしなので literal で正しい) | `/log` ✅ |
| `/logs/:path+` | `/logs/rss.xml` | `{path:["rss.xml"]}` | `/log/rss.xml` ✅ |

### 修正

0 セグメントケースをプレースホルダなしの完全一致ルールに分離:

- `/logs` → `/log`(exact, literal 同士)
- `/logs/:path+` → `/log/:path+`(`+` = 1 セグメント以上なので必ずコンパイルされる)

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` グリーン
- [x] path-to-regexp 6.3.0 で OpenNext の置換ロジックを再現し、全ケースの Location を確認
- [ ] staging デプロイ後、`curl -I https://stg.napochaan.com/logs` が `location: /log` を返すこと
- [ ] `curl -I https://stg.napochaan.com/logs/rss.xml` が `location: /log/rss.xml` を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)