### PR TITLE
fix: /logs リダイレクトを完全一致のみに簡略化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,18 +17,14 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['drizzle-kit', 'esbuild', 'esbuild-register'],
   redirects: async () => [
     // The public route is /log (the CMS collection slug is `logs`, so /logs is a
-    // natural guess). Kept as two rules instead of one `/logs/:path*`: OpenNext's
-    // routing layer only compiles the destination when the source match produced
-    // params, so a zero-segment `:path*` match leaves the literal ":path*" in the
-    // Location header. Exact + `:path+` (one or more segments) avoids that case.
+    // natural guess). Exact match only — /log has no detail pages, so there is
+    // nothing meaningful to map sub-paths onto. Placeholder rules (`:path*`) are
+    // also risky here: OpenNext's routing layer skips destination compilation
+    // when the source match yields no params, leaving a literal ":path*" in the
+    // Location header (bit us on staging).
     {
       source: '/logs',
       destination: '/log',
-      permanent: true,
-    },
-    {
-      source: '/logs/:path+',
-      destination: '/log/:path+',
       permanent: true,
     },
   ],


### PR DESCRIPTION
## Summary

`/log` に詳細ページは存在しないため、下層パスをマッピングする `/logs/:path+` ルールを削除し、`/logs` → `/log` の完全一致 1 ルールだけにする。

プレースホルダ付きルールは OpenNext routing layer の未コンパイル問題(source マッチで params が空だと destination の `:path+` が literal のまま Location に入る — staging で発生済み)の温床にもなるため、使わないものは持たない。

## 補足: 「まだ `/log/:path*` に飛ぶ」件

staging のサーバー側は PR #16 の Deploy(13:59 UTC 完了)で既に修正済み。まだ literal URL に遷移するのは、**壊れていた時期の 308(permanent)をブラウザがキャッシュしている**ため。permanent redirect はブラウザが再問い合わせせずキャッシュから遷移するので、シークレットウィンドウか対象サイトのキャッシュ削除で解消する。

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` グリーン
- [ ] staging デプロイ後、シークレットウィンドウで `https://stg.napochaan.com/logs` が `/log` に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)