### PR TITLE
feat(mcp): add HMAC-signed upload URL flow for local media files

### DIFF
--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -5,6 +5,9 @@ const findByID = vi.fn();
 vi.mock('@lib/payload/client', () => ({
   getPayloadClient: async () => ({ findByID, config: { editor: { editorConfig: {} } } }),
 }));
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: async () => ({ env: { PAYLOAD_SECRET: 'test-payload-secret' } }),
+}));
 vi.mock('@payloadcms/richtext-lexical', () => ({
   editorConfigFactory: { fromFeatures: async () => ({}) },
   convertMarkdownToLexical: () => ({}),

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,3 +1,4 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { editorConfigFactory } from '@payloadcms/richtext-lexical';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -44,10 +45,14 @@ const handleMCPRequest = async (request: Request): Promise<Response> => {
   //     「multiple copies of lexical」で block 変換が throw する(next dev/バンドル環境)。
   const editorConfig = await editorConfigFactory.fromFeatures({ config: payload.config, features: blogEditorFeatures });
 
+  // create_upload_url が発行する署名付き URL の HMAC secret。Payload 自体の secret を
+  // 再利用する(専用 secret を新設せず、既存の秘匿値を流用する設計判断)。
+  const { env } = await getCloudflareContext({ async: true });
+
   // MCP SDK 1.26+ はリクエストごとに server / transport を新規生成する必要がある
   // (共有すると "already connected" で throw する)。生成は安価。
   const server = new McpServer({ name: 'napochaan-blog', version: '1.0.0' });
-  registerBlogTools(server, { payload, user, codec: createMarkdownCodec(editorConfig) });
+  registerBlogTools(server, { payload, user, codec: createMarkdownCodec(editorConfig), signingSecret: env.PAYLOAD_SECRET });
 
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined, // stateless モード

--- a/src/app/api/media-upload/route.test.ts
+++ b/src/app/api/media-upload/route.test.ts
@@ -1,0 +1,308 @@
+import { ValidationError } from 'payload';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MAX_UPLOAD_BYTES, signUploadURLParams } from '@lib/mcp/upload-url';
+
+import type { UploadURLParams } from '@lib/mcp/upload-url';
+
+const SECRET = 'test-payload-secret';
+const NOW = 1_700_000_000;
+
+const findByID = vi.fn();
+const create = vi.fn();
+
+vi.mock('@lib/payload/client', () => ({
+  getPayloadClient: async () => ({ findByID, create }),
+}));
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: async () => ({ env: { PAYLOAD_SECRET: SECRET } }),
+}));
+
+const { POST } = await import('./route');
+
+const baseParams = (): UploadURLParams => ({ userID: 1, exp: NOW + 600, filename: 'cover.png', alt: 'テスト画像' });
+
+type QueryOverrides = Partial<Record<'user' | 'exp' | 'filename' | 'alt' | 'sig', string>>;
+
+// 実 signUploadURLParams で有効な sig を作り、URLSearchParams のクエリを組む。
+// overrides で任意フィールドを上書き/削除して不正系ケースを作る。
+const buildSignedURL = async (params: UploadURLParams, overrides: QueryOverrides = {}): Promise<string> => {
+  const sig = await signUploadURLParams(SECRET, params);
+  const search = new URLSearchParams({
+    user: `${params.userID}`,
+    exp: `${params.exp}`,
+    filename: params.filename,
+    alt: params.alt,
+    sig,
+  });
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      search.delete(key);
+      continue;
+    }
+    search.set(key, value);
+  }
+  return `http://localhost/api/media-upload?${search.toString()}`;
+};
+
+const postRequest = (url: string, body?: BodyInit, headers?: Record<string, string>): Request => new Request(url, { method: 'POST', body, headers });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW * 1000);
+  findByID.mockReset();
+  create.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('POST /api/media-upload', () => {
+  describe('missing required params', () => {
+    it.each(['user', 'exp', 'filename', 'alt', 'sig'] as const)('returns 400 when %s is missing', async (key) => {
+      const url = await buildSignedURL(baseParams(), { [key]: undefined });
+
+      const response = await POST(postRequest(url, new Uint8Array([1])));
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it('returns 400 when user is non-numeric', async () => {
+    const url = await buildSignedURL(baseParams(), { user: 'abc' });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when exp is non-numeric', async () => {
+    const url = await buildSignedURL(baseParams(), { exp: 'abc' });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(400);
+  });
+
+  // 数字のみを要求する digits-regex は parseInt の桁先頭一致(旧実装は parseInt("1abc",10)===1
+  // を許してしまい、元の署名と偶然同じ数値になって検証を通り得た)より厳格。ここでは 400 になる
+  // ことを固定する — 401(署名不一致)にはならない、つまり事前に弾かれる。
+  it('returns 400 when user has a valid numeric prefix but trailing non-digit characters', async () => {
+    const url = await buildSignedURL(baseParams(), { user: '1abc' });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when alt is present but an empty string (treated the same as missing)', async () => {
+    const url = await buildSignedURL(baseParams(), { alt: '' });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 401 when sig is tampered', async () => {
+    const url = await buildSignedURL(baseParams(), { sig: 'deadbeef' });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 401 when sig was minted for a different alt', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, { ...params, alt: '別のalt' });
+    const search = new URLSearchParams({ user: `${params.userID}`, exp: `${params.exp}`, filename: params.filename, alt: params.alt, sig });
+
+    const response = await POST(postRequest(`http://localhost/api/media-upload?${search.toString()}`, new Uint8Array([1])));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 401 when a sig minted for one filename is replayed with a different filename', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const search = new URLSearchParams({ user: `${params.userID}`, exp: `${params.exp}`, filename: 'other.png', alt: params.alt, sig });
+
+    const response = await POST(postRequest(`http://localhost/api/media-upload?${search.toString()}`, new Uint8Array([1])));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 401 when a sig minted for one userID is replayed with a different user', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const search = new URLSearchParams({ user: `${params.userID + 1}`, exp: `${params.exp}`, filename: params.filename, alt: params.alt, sig });
+
+    const response = await POST(postRequest(`http://localhost/api/media-upload?${search.toString()}`, new Uint8Array([1])));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 410 when exp is expired', async () => {
+    const url = await buildSignedURL({ ...baseParams(), exp: NOW - 1 });
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(410);
+  });
+
+  it('returns 401 when the signed user is unknown (findByID -> null)', async () => {
+    findByID.mockResolvedValue(null);
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array([1])));
+
+    expect(response.status).toBe(401);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when content-length exceeds the 10MB cap', async () => {
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3]), { 'content-length': `${MAX_UPLOAD_BYTES + 1}` }));
+
+    expect(response.status).toBe(413);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns 413 when the actual body exceeds the 10MB cap without a content-length header', async () => {
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, Buffer.alloc(MAX_UPLOAD_BYTES + 1)));
+
+    expect(response.status).toBe(413);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  // 署名検証は body の buffering(bodyLimit)より前に実行されなければならない —
+  // そうしないと無署名/不正署名のリクエストでも攻撃者が任意サイズの body を
+  // 送りつけてワーカーに buffering させられる(認可境界がボディ読み取りの前段にある
+  // ことの固定テスト)。sig を改竄したまま 11MB(無 content-length)を送っても
+  // 413(bodyLimit)ではなく 401(署名検証)が返るはず — 413 が返るなら body が
+  // 先に drain されてしまっている。
+  it('returns 401 (not 413) when sig is tampered and the body is 11MB without a content-length header', async () => {
+    const url = await buildSignedURL(baseParams(), { sig: 'deadbeef' });
+
+    const response = await POST(postRequest(url, Buffer.alloc(MAX_UPLOAD_BYTES + 1)));
+
+    expect(response.status).toBe(401);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty body', async () => {
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array(0)));
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when a genuinely signed filename has an unresolvable MIME extension', async () => {
+    const params = { ...baseParams(), filename: 'file.txt' };
+    const url = await buildSignedURL(params);
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3])));
+
+    expect(response.status).toBe(400);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with joined field messages when payload.create rejects with a ValidationError', async () => {
+    const user = { id: 1, email: 'dev@napochaan.com' };
+    findByID.mockResolvedValue(user);
+    create.mockRejectedValue(
+      new ValidationError({
+        errors: [
+          { path: 'alt', message: 'alt is required' },
+          { path: 'filename', message: 'filename is invalid' },
+        ],
+      }),
+    );
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3])));
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('alt: alt is required');
+    expect(body.error).toContain('filename: filename is invalid');
+  });
+
+  // formatUploadError の cause 判定は再帰的に辿る(直下だけでなく、間に素の Error が
+  // 挟まっていても奥まで見る)。ここでは PayloadOperationError.cause = Error('outer') の
+  // さらに .cause に ValidationError を1段深く仕込み、それでも 400 に畳まれることを確認する。
+  it('returns 400 with joined field messages when the ValidationError is nested one level deeper in the cause chain', async () => {
+    const user = { id: 1, email: 'dev@napochaan.com' };
+    findByID.mockResolvedValue(user);
+    create.mockRejectedValue(
+      new Error('outer', {
+        cause: new ValidationError({
+          errors: [{ path: 'alt', message: 'alt is required' }],
+        }),
+      }),
+    );
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3])));
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain('alt: alt is required');
+  });
+
+  it('returns 500 instead of overflowing when the cause chain is cyclic', async () => {
+    const user = { id: 1, email: 'dev@napochaan.com' };
+    findByID.mockResolvedValue(user);
+    const cyclic = new Error('outer');
+    cyclic.cause = cyclic;
+    create.mockRejectedValue(cyclic);
+    const url = await buildSignedURL(baseParams());
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3])));
+
+    expect(response.status).toBe(500);
+  });
+
+  it('creates the media doc and returns 201 on a valid request', async () => {
+    const user = { id: 1, email: 'dev@napochaan.com' };
+    findByID.mockResolvedValue(user);
+    create.mockResolvedValue({ id: 42, url: '/media/cover.png' });
+    const params = baseParams();
+    const url = await buildSignedURL(params);
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+
+    const response = await POST(postRequest(url, bytes));
+    const body = (await response.json()) as { id: number; placeholder: string; url?: string };
+
+    expect(response.status).toBe(201);
+    expect(body.id).toBe(42);
+    expect(body.placeholder).toBe(`![media:42](${params.alt})`);
+    expect(body.url).toBe('/media/cover.png');
+    expect(create).toHaveBeenCalledWith({
+      collection: 'media',
+      data: { alt: params.alt },
+      file: { data: Buffer.from(bytes), mimetype: 'image/png', name: params.filename, size: bytes.byteLength },
+      overrideAccess: false,
+      user,
+    });
+  });
+
+  it('round-trips a multibyte (Japanese) alt through URL encoding into the placeholder', async () => {
+    const user = { id: 1, email: 'dev@napochaan.com' };
+    findByID.mockResolvedValue(user);
+    create.mockResolvedValue({ id: 7, url: null });
+    const params = { ...baseParams(), alt: '桜と富士山の写真、とても美しい景色です' };
+    const url = await buildSignedURL(params);
+
+    const response = await POST(postRequest(url, new Uint8Array([1, 2, 3])));
+    const body = (await response.json()) as { placeholder: string; url?: string };
+
+    expect(response.status).toBe(201);
+    expect(body.placeholder).toBe(`![media:7](${params.alt})`);
+    expect(body.url).toBeUndefined();
+  });
+});

--- a/src/app/api/media-upload/route.ts
+++ b/src/app/api/media-upload/route.ts
@@ -1,0 +1,184 @@
+import { zValidator } from '@hono/zod-validator';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { handle } from 'hono/vercel';
+import { err, errAsync, fromPromise, ok, okAsync } from 'neverthrow';
+import { ValidationError } from 'payload';
+import { z } from 'zod';
+
+import { EmptyUploadBodyError, formatPayloadValidationError, MimeTypeError, PayloadOperationError, UnknownUploadUserError, UploadURLExpiredError, UploadURLSignatureError } from '@lib/mcp/errors';
+import { MAX_UPLOAD_BYTES, resolveMimetypeFromFilename, verifyUploadURLParams } from '@lib/mcp/upload-url';
+import { getPayloadClient } from '@lib/payload/client';
+
+import type { Media, User } from '@payload-types';
+import type { Context } from 'hono';
+import type { Result, ResultAsync } from 'neverthrow';
+import type { Payload } from 'payload';
+
+// このパスは意図的に /api/mcp の外に置く — /api/mcp/* は worker の mcp-guard が
+// 公開側から 404 遮断するため。認可はクエリの HMAC 署名(create_upload_url が発行)
+// のみで行う。
+
+const MISSING_PARAM_MESSAGE = 'user, exp, filename, alt, sig は全て必須です。create_upload_url で発行した URL をそのまま使用してください。';
+const INVALID_NUMBER_MESSAGE = 'user, exp は数値で指定してください。create_upload_url で発行した URL をそのまま使用してください。';
+const MIME_TYPE_MESSAGE = 'filename の拡張子から MIME type を特定できません(対応: jpg / jpeg / png / webp / gif / avif)。正しい拡張子付きの filename で create_upload_url を発行し直してください。';
+const TOO_LARGE_MESSAGE = '画像が大きすぎます(上限 10MB)。縮小・圧縮してから再実行してください。';
+const EMPTY_BODY_MESSAGE = 'ファイルが空です。画像データを body にセットして再送してください。';
+const UNKNOWN_USER_MESSAGE = '指定された user が見つかりません。create_upload_url を発行したユーザーで再実行してください。';
+const INTERNAL_ERROR_MESSAGE = '内部エラーが発生しました。時間をおいて再実行してください。';
+const SUCCESS_NOTE = '本文にはこの placeholder をそのまま貼る。thumbnail には id を thumbnailMediaID に渡す。';
+
+// user / exp は「数字のみの文字列」を要求する(z.coerce.number は不使用 — parseFloat 等の
+// 緩い変換規則を経由させず、桁の見た目どおりの値だけを受理するため)。
+const digitsToInt = z
+  .string()
+  .regex(/^\d+$/)
+  .transform((value) => parseInt(value, 10));
+
+const querySchema = z.object({
+  user: digitsToInt,
+  exp: digitsToInt,
+  filename: z.string().min(1),
+  alt: z.string().min(1),
+  sig: z.string().min(1),
+});
+
+type ParsedQuery = z.infer<typeof querySchema>;
+
+const REQUIRED_QUERY_KEYS = ['user', 'exp', 'filename', 'alt', 'sig'] as const;
+
+// 旧 readRawParams と同じ判定(1つでも未指定/空文字なら false)。zValidator の
+// hook から呼び、「未指定/空」と「指定はあるが数値として不正」の 2 つの 400 を
+// 呼び分ける(前者を優先する既存の優先順位を保つ)。
+const hasAllRequiredQueryParams = (c: Context): boolean =>
+  REQUIRED_QUERY_KEYS.every((key) => {
+    const value = c.req.query(key);
+    return value !== undefined && value !== '';
+  });
+
+// 発行時点では拡張子を検証済みのはずだが、境界を跨ぐ入力は常に fail closed で
+// 再検証する(署名は filename の拡張子妥当性までは保証しない)。
+const resolveMimetype = (filename: string): Result<string, MimeTypeError> => {
+  const mimetype = resolveMimetypeFromFilename(filename);
+  return mimetype === undefined ? err(new MimeTypeError(MIME_TYPE_MESSAGE)) : ok(mimetype);
+};
+
+const findUploadUser = (payload: Payload, userID: number): ResultAsync<User, UnknownUploadUserError | PayloadOperationError> =>
+  fromPromise(payload.findByID({ collection: 'users', id: userID, disableErrors: true, overrideAccess: true }), (cause) => new PayloadOperationError('user 取得に失敗しました', { cause })).andThen(
+    (user) => (user === null ? errAsync(new UnknownUploadUserError(UNKNOWN_USER_MESSAGE)) : okAsync(user)),
+  );
+
+const createMediaDoc = (payload: Payload, user: User, parsed: ParsedQuery, mimetype: string, data: ArrayBuffer): ResultAsync<Media, PayloadOperationError> =>
+  fromPromise(
+    payload.create({
+      collection: 'media',
+      data: { alt: parsed.alt },
+      file: { data: Buffer.from(data), mimetype, name: parsed.filename, size: data.byteLength },
+      overrideAccess: false,
+      user,
+    }),
+    (cause) => new PayloadOperationError('media 作成に失敗しました', { cause }),
+  );
+
+// このルートで生成され得るエラー全種(署名検証 edge / ハンドラ edge の両方)。
+type UploadRouteError = UploadURLExpiredError | UploadURLSignatureError | MimeTypeError | EmptyUploadBodyError | UnknownUploadUserError | PayloadOperationError;
+
+type FormattedUploadError = { status: 400 | 401 | 410 | 500; message: string };
+
+// 循環した cause チェーン(error.cause === error 等)での再帰暴走を防ぐ深さ上限。
+const MAX_CAUSE_DEPTH = 8;
+
+// PayloadOperationError.cause を再帰的に辿り、ValidationError が現れた最初の階層で
+// 400 に畳む。cause チェーンの途中に(ラップ用の)素の Error が挟まっていても、
+// そのさらに cause を辿り続ける(ユーザー指示: 「cause も触れるように再帰関数にしたい」)。
+const formatUploadErrorCause = (cause: unknown, depth = 0): FormattedUploadError | undefined => {
+  if (depth >= MAX_CAUSE_DEPTH) return undefined;
+  if (cause instanceof ValidationError) return { status: 400, message: formatPayloadValidationError(cause) };
+  if (cause instanceof Error) return formatUploadErrorCause(cause.cause, depth + 1);
+  return undefined;
+};
+
+// エラー→ステータス/メッセージの対応。name は as const でリテラル型化済みなので、
+// string-literal union の discriminant として switch で分岐できる
+// (branching-modeled-state-with-switch)。default は置かず、tsgo の網羅性検査
+// (switch 後に到達不能な分岐がなければ全パス return 済みと判定される)に委ねる。
+// PayloadOperationError だけ cause の中身次第で 400/500 が分かれるため、
+// cause 側の判定は再帰の formatUploadErrorCause に委譲する。
+const formatUploadError = (error: UploadRouteError): FormattedUploadError => {
+  switch (error.name) {
+    case 'UploadURLExpiredError':
+      return { status: 410, message: error.message };
+    case 'UploadURLSignatureError':
+      return { status: 401, message: error.message };
+    case 'MimeTypeError':
+      return { status: 400, message: error.message };
+    case 'EmptyUploadBodyError':
+      return { status: 400, message: error.message };
+    case 'UnknownUploadUserError':
+      return { status: 401, message: error.message };
+    case 'PayloadOperationError':
+      return formatUploadErrorCause(error.cause) ?? { status: 500, message: INTERNAL_ERROR_MESSAGE };
+  }
+};
+
+// 署名検証 edge / ハンドラ edge 共通のレスポンス整形。500(internal fallback)の
+// ときだけ、元の cause チェーンをそのまま(整形後オブジェクトではなく)ログに残す —
+// 旧 toErrorResponse の console.error 文言・タイミングを踏襲。
+const toUploadErrorResponse = (c: Context, error: UploadRouteError): Response => {
+  const formatted = formatUploadError(error);
+  if (formatted.status === 500) console.error('[media-upload] media 作成に失敗しました', error.cause);
+  return c.json({ error: formatted.message }, formatted.status);
+};
+
+const app = new Hono();
+
+app.post(
+  '/api/media-upload',
+  zValidator('query', querySchema, (result, c) => {
+    if (result.success) return undefined;
+    if (!hasAllRequiredQueryParams(c)) return c.json({ error: MISSING_PARAM_MESSAGE }, 400);
+    return c.json({ error: INVALID_NUMBER_MESSAGE }, 400);
+  }),
+  // 署名検証は bodyLimit より前 — 無署名/不正署名のリクエストで body を buffering
+  // しないため(順序それ自体が認可境界の一部)。署名の唯一のソースは
+  // create_upload_url が発行時に使った secret(Payload 自体の secret を流用)。
+  // ここが実質的な認可境界であり、他に認証手段は存在しない(fail closed)。
+  async (c, next) => {
+    const parsed = c.req.valid('query');
+    const { env } = await getCloudflareContext({ async: true });
+    return verifyUploadURLParams(env.PAYLOAD_SECRET, { userID: parsed.user, exp: parsed.exp, filename: parsed.filename, alt: parsed.alt }, parsed.sig, Math.floor(Date.now() / 1000)).match(
+      () => next(),
+      (error) => toUploadErrorResponse(c, error),
+    );
+  },
+  bodyLimit({ maxSize: MAX_UPLOAD_BYTES, onError: (c) => c.json({ error: TOO_LARGE_MESSAGE }, 413) }),
+  async (c) => {
+    const parsed = c.req.valid('query');
+    const data = await c.req.arrayBuffer();
+
+    return resolveMimetype(parsed.filename)
+      .andThen((mimetype) => (data.byteLength === 0 ? err(new EmptyUploadBodyError(EMPTY_BODY_MESSAGE)) : ok(mimetype)))
+      .asyncAndThen((mimetype) =>
+        fromPromise(getPayloadClient(), (cause) => new PayloadOperationError('Payload client の初期化に失敗しました', { cause })).andThen((payload) =>
+          findUploadUser(payload, parsed.user).map((user) => ({ payload, mimetype, user })),
+        ),
+      )
+      .andThen(({ payload, user, mimetype }) => createMediaDoc(payload, user, parsed, mimetype, data))
+      .match(
+        (media) =>
+          c.json(
+            {
+              id: media.id,
+              placeholder: `![media:${media.id}](${parsed.alt})`,
+              url: media.url ?? undefined,
+              note: SUCCESS_NOTE,
+            },
+            201,
+          ),
+        (error) => toUploadErrorResponse(c, error),
+      );
+  },
+);
+
+export const POST = handle(app);

--- a/src/lib/mcp/errors/index.ts
+++ b/src/lib/mcp/errors/index.ts
@@ -1,51 +1,76 @@
+import type { ValidationError } from 'payload';
+
 // MCP blog tool の error channel。すべての失敗はここに集約する(modeling-errors-as-classes)。
 // `override name` は noImplicitOverride 対応(Error.name の上書き)。判別は instanceof で行う —
 // name は log / IPC シリアライズ後の wire 判別子用の安定 ID であって、in-process の判別子ではない。
+// `as const` でリテラル型化しているため、name は string-literal union の discriminant としても
+// 使える(POST /api/media-upload の formatUploadError が name で switch する用途)。
 
 // 入力が discriminated union にパースできない(id/slug どちらも未指定、url/base64 どちらも未指定 等)。
 export class InvalidInputError extends Error {
-  override name = 'InvalidInputError';
+  override name = 'InvalidInputError' as const;
 }
 
 // 指定 id/slug の blog 記事が見つからない。
 export class PostNotFoundError extends Error {
-  override name = 'PostNotFoundError';
+  override name = 'PostNotFoundError' as const;
 }
 
 // 指定 id の media が見つからない。thumbnail / image-row cell の両方で使うため、
 // メッセージは呼び出し側が渡す(文言がユースケースごとに異なるため)。
 export class MediaNotFoundError extends Error {
-  override name = 'MediaNotFoundError';
+  override name = 'MediaNotFoundError' as const;
 }
 
 // 既存本文に MCP 非対応の block が含まれ、bodyMarkdown での上書きができない。
 export class UnsupportedBlockError extends Error {
-  override name = 'UnsupportedBlockError';
+  override name = 'UnsupportedBlockError' as const;
 }
 
 // 本文 Markdown の検証エラー(生 URL 画像参照 / image-row フェンス構文違反)。
 export class BodyValidationError extends Error {
-  override name = 'BodyValidationError';
+  override name = 'BodyValidationError' as const;
 }
 
 // アップロード元 URL の形式・スキーム・ホストが不正(SSRF ガード)。
 export class ImageURLError extends Error {
-  override name = 'ImageURLError';
+  override name = 'ImageURLError' as const;
 }
 
 // アップロード元 URL の取得に失敗(リダイレクト・ネットワークエラー・非 2xx)。
 export class ImageFetchError extends Error {
-  override name = 'ImageFetchError';
+  override name = 'ImageFetchError' as const;
 }
 
 // アップロード画像が上限サイズを超過(content-length 事前チェック or 受信量の実測)。
 export class UploadTooLargeError extends Error {
-  override name = 'UploadTooLargeError';
+  override name = 'UploadTooLargeError' as const;
 }
 
 // アップロード画像の MIME type を特定できない。
 export class MimeTypeError extends Error {
-  override name = 'MimeTypeError';
+  override name = 'MimeTypeError' as const;
+}
+
+// 署名付き upload URL の期限切れ。
+export class UploadURLExpiredError extends Error {
+  override name = 'UploadURLExpiredError' as const;
+}
+
+// 署名付き upload URL の署名不一致・不正。
+export class UploadURLSignatureError extends Error {
+  override name = 'UploadURLSignatureError' as const;
+}
+
+// POST /api/media-upload のボディが 0 バイト(未送信/空送信)。
+export class EmptyUploadBodyError extends Error {
+  override name = 'EmptyUploadBodyError' as const;
+}
+
+// POST /api/media-upload の署名は正当だが、対応する user が見つからない
+// (findByID -> null)。署名自体の検証は通っているため、失効/改竄と区別する。
+export class UnknownUploadUserError extends Error {
+  override name = 'UnknownUploadUserError' as const;
 }
 
 // payload.* / codec.* が投げた例外を Result channel に折り込むラッパ。生の例外は
@@ -53,9 +78,20 @@ export class MimeTypeError extends Error {
 // `cause instanceof ValidationError` ならフィールド単位の詳細メッセージを、
 // それ以外は internal error 文言 + console.error でのログ出力を行う。
 export class PayloadOperationError extends Error {
-  override name = 'PayloadOperationError';
+  override name = 'PayloadOperationError' as const;
 }
 
+// PayloadOperationError.cause が ValidationError のときの、フィールド単位メッセージの
+// 整形(house style)。tools/index.ts の toToolError と POST /api/media-upload の両方が使う —
+// 同じ文言を 2 箇所で保守すると必ず乖離するため、ここに一本化する。
+export const formatPayloadValidationError = (error: ValidationError): string => {
+  const details = (error.data.errors ?? []).map((item) => `- ${item.path ?? '(field)'}: ${item.message}`).join('\n');
+  return `Payload の入力検証に失敗しました:\n${details}\n該当フィールドを修正して再実行してください。`;
+};
+
+// UploadURLExpiredError / UploadURLSignatureError は POST /api/media-upload
+// (src/lib/mcp/upload-url の verifyUploadURLParams)専用のエラーで、MCP tool 側
+// (src/lib/mcp/tools)では一切生成されないため McpToolError には含めない。
 export type McpToolError =
   | InvalidInputError
   | PostNotFoundError

--- a/src/lib/mcp/tools/index.ts
+++ b/src/lib/mcp/tools/index.ts
@@ -7,6 +7,7 @@ import { absoluteUrl } from '@utils/site-url';
 
 import {
   BodyValidationError,
+  formatPayloadValidationError,
   ImageFetchError,
   ImageURLError,
   InvalidInputError,
@@ -20,6 +21,7 @@ import {
 import { blockSyntaxHelp, extractBlockMediaIDs, hasUnsupportedBlocks, validateBlockFences } from '../markdown';
 import { mapTextSegments, splitCodeFences } from '../markdown/code-fences';
 import { hasNonEmptyParens, isRoundTrippableAlt, parseInlineNodes, serializeImageRef, serializeInlineNodes } from '../markdown/image-ref';
+import { MAX_UPLOAD_BYTES, UPLOAD_URL_TTL_SECONDS, resolveMimetypeFromFilename, signUploadURLParams } from '../upload-url';
 
 import { createRawRefHint } from './raw-ref-hints';
 
@@ -36,6 +38,7 @@ export type BlogToolDeps = {
   payload: Payload;
   user: User;
   codec: MarkdownCodec;
+  signingSecret: string;
 };
 
 export type ToolResult = {
@@ -52,10 +55,7 @@ const fail = (message: string): ToolResult => ({ content: [{ type: 'text', text:
 // 分岐が要るので個別分岐、それ以外は自身の message がそのままユーザー向け文言。
 const toToolError = (error: McpToolError): ToolResult => {
   if (error instanceof PayloadOperationError) {
-    if (error.cause instanceof ValidationError) {
-      const details = (error.cause.data.errors ?? []).map((item) => `- ${item.path ?? '(field)'}: ${item.message}`).join('\n');
-      return fail(`Payload の入力検証に失敗しました:\n${details}\n該当フィールドを修正して再実行してください。`);
-    }
+    if (error.cause instanceof ValidationError) return fail(formatPayloadValidationError(error.cause));
     console.error('[mcp] tool error', error.message, error.cause);
     return fail('内部エラーが発生しました。同一入力での再試行は避け、ユーザーに状況を報告してください。');
   }
@@ -78,27 +78,6 @@ const BODY_MARKDOWN_HELP = [
   '',
   'なお image-row フェンス内セルの括弧は caption であり alt ではない(セルの alt は media 側の alt が使われる)。',
 ].join('\n');
-
-const MIME_BY_EXT = {
-  avif: 'image/avif',
-  gif: 'image/gif',
-  jpeg: 'image/jpeg',
-  jpg: 'image/jpeg',
-  png: 'image/png',
-  webp: 'image/webp',
-} satisfies Record<string, string>;
-
-type ImageExtension = keyof typeof MIME_BY_EXT;
-
-const isImageExtension = (ext: string): ext is ImageExtension => Object.hasOwn(MIME_BY_EXT, ext);
-
-const resolveMimetypeFromFilename = (filename: string): string | undefined => {
-  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-  return isImageExtension(ext) ? MIME_BY_EXT[ext] : undefined;
-};
-
-// Workers の isolate メモリ保護。media は画像/PDF 想定。
-const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
 const UPLOAD_TOO_LARGE_MESSAGE = '画像が大きすぎます(上限 10MB)。縮小・圧縮してから再実行してください。';
 
@@ -129,13 +108,20 @@ const parseUploadInput = (input: { url?: string; base64?: string }): Result<Uplo
   return errResult(new InvalidInputError('url か base64 のどちらかを指定してください。'));
 };
 
+const MIME_TYPE_ERROR_MESSAGE = 'MIME type を特定できません。filename に拡張子(jpg/png/webp/gif/avif)を付けて再実行してください。';
+
 const resolveUploadMimetype = (source: UploadSource, filename: string): Result<string, MimeTypeError> => {
   const mimetype = source.mimetype ?? resolveMimetypeFromFilename(filename);
   if (mimetype === undefined) {
-    return errResult(new MimeTypeError('MIME type を特定できません。filename に拡張子(jpg/png/webp/gif/avif)を付けて再実行してください。'));
+    return errResult(new MimeTypeError(MIME_TYPE_ERROR_MESSAGE));
   }
   return okResult(mimetype);
 };
+
+// create_upload_url は実バイトを持たないため resolveUploadMimetype(source ベース)は使えず、
+// 拡張子だけを見て事前に拒否する(実際の MIME 判定は POST /api/media-upload 側で行う)。
+const validateUploadFilenameExtension = (filename: string): Result<void, MimeTypeError> =>
+  resolveMimetypeFromFilename(filename) === undefined ? errResult(new MimeTypeError(MIME_TYPE_ERROR_MESSAGE)) : okResult(undefined);
 
 const isPrivateIPv4 = (hostname: string): boolean => {
   const octets = hostname.split('.');
@@ -473,7 +459,7 @@ const verifyThumbnailIfProvided = (verifyMediaExists: VerifyMediaExists, thumbna
 };
 
 export const createBlogToolHandlers = (deps: BlogToolDeps) => {
-  const { payload, user, codec } = deps;
+  const { payload, user, codec, signingSecret } = deps;
 
   const toLexicalSafe: ToLexicalSafe = fromThrowable(
     (markdown: string) => codec.toLexical(markdown),
@@ -672,6 +658,29 @@ export const createBlogToolHandlers = (deps: BlogToolDeps) => {
         }))
         .match(ok, toToolError),
 
+    createUploadURL: (input: { filename: string; alt: string }): Promise<ToolResult> =>
+      validateUploadAlt(input.alt)
+        .andThen(() => validateUploadFilenameExtension(input.filename))
+        .asyncAndThen(() => {
+          const exp = Math.floor(Date.now() / 1000) + UPLOAD_URL_TTL_SECONDS;
+          return fromPromise(
+            signUploadURLParams(signingSecret, { userID: user.id, exp, filename: input.filename, alt: input.alt }),
+            (cause) => new PayloadOperationError('署名の生成に失敗しました', { cause }),
+          ).map((sig) => ({ exp, sig }));
+        })
+        .map(({ exp, sig }) => {
+          const params = new URLSearchParams({ user: `${user.id}`, exp: `${exp}`, filename: input.filename, alt: input.alt, sig });
+          const uploadURL = `${absoluteUrl('/api/media-upload')}?${params.toString()}`;
+          return {
+            uploadURL,
+            method: 'POST',
+            expiresAt: dayjs.unix(exp).tz('Asia/Tokyo').format(),
+            curlExample: `curl -sS -X POST --data-binary @<ローカル画像のパス> '${uploadURL}'`,
+            note: 'シェルで curlExample を実行する(@ の後を実ファイルパスに置換)。成功レスポンスの placeholder を本文にそのまま貼り、thumbnail には id を使う。上限 10MB、URL は発行から 10 分で失効。ワンタイムではないが期限内のみ有効。',
+          };
+        })
+        .match(ok, toToolError),
+
     createPost: (input: { title: string; slug: string; excerpt: string; thumbnailMediaID: number; bodyMarkdown: string; publishedAt?: string }): Promise<ToolResult> =>
       // thumbnail 検証を prepareBody より先に行う: prepareBody は media doc alt 更新を
       // コミットする副作用を持つため、先に body を用意すると不正な thumbnailMediaID で
@@ -835,7 +844,7 @@ export const registerBlogTools = (server: McpServer, deps: BlogToolDeps): void =
     {
       title: '画像アップロード',
       description:
-        '画像を media コレクションに登録し、本文用プレースホルダ ![media:<id>](alt) と thumbnail 用の id を返す。本文への画像埋め込み・thumbnail 指定の前に必ずこれを使う。サイズ上限は 10MB(超過時はエラーになるため事前に縮小・圧縮すること)。',
+        '画像を media コレクションに登録し、本文用プレースホルダ ![media:<id>](alt) と thumbnail 用の id を返す。本文への画像埋め込み・thumbnail 指定の前に必ずこれを使う。サイズ上限は 10MB(超過時はエラーになるため事前に縮小・圧縮すること)。ローカルファイルパスから上げたい場合は create_upload_url を使う。',
       inputSchema: {
         url: z.string().url().optional().describe('取得元 URL(url か base64 のどちらか必須。ダウンロードサイズ上限 10MB)'),
         base64: z.string().optional().describe('画像バイナリの base64(デコード後サイズ上限 10MB)'),
@@ -845,6 +854,21 @@ export const registerBlogTools = (server: McpServer, deps: BlogToolDeps): void =
       annotations: { destructiveHint: false },
     },
     handlers.uploadMedia,
+  );
+
+  server.registerTool(
+    'create_upload_url',
+    {
+      title: 'ローカルファイル用 upload URL 発行',
+      description:
+        'URL でも base64 でも渡せない手元のファイルを上げるときに使う。返る curlExample を Bash で実行するとアップロードされ、レスポンスに media id と placeholder が返る。url/base64 を直接渡せる場合は upload_media を使う。',
+      inputSchema: {
+        filename: z.string().min(1).describe('拡張子付きファイル名。jpg/jpeg/png/webp/gif/avif のみ'),
+        alt: z.string().min(1).refine(isRoundTrippableAlt, ALT_CLOSE_PAREN_MESSAGE).describe('代替テキスト(必須。半角 ")" は使用不可 — 全角「）」を使うこと)'),
+      },
+      annotations: { destructiveHint: false },
+    },
+    handlers.createUploadURL,
   );
 
   server.registerTool(

--- a/src/lib/mcp/tools/tools.test.ts
+++ b/src/lib/mcp/tools/tools.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { verifyUploadURLParams } from '../upload-url';
+
 import { createBlogToolHandlers } from '.';
 
 import type { BlogToolDeps } from '.';
@@ -18,6 +20,7 @@ afterEach(() => {
 });
 
 const user = { id: 1, email: 'dev@napochaan.com' } as User;
+const SIGNING_SECRET = 'test-signing-secret';
 
 const paragraphBody = (): Blog['body'] => ({ root: { type: 'root', children: [{ type: 'paragraph', version: 1 }], direction: null, format: '', indent: 0, version: 1 } }) as Blog['body'];
 
@@ -34,7 +37,7 @@ const createDeps = () => {
     toLexical: vi.fn((_markdown: string) => paragraphBody()),
     toMarkdown: vi.fn(() => '# md'),
   };
-  const deps = { payload, user, codec } as unknown as BlogToolDeps;
+  const deps = { payload, user, codec, signingSecret: SIGNING_SECRET } as unknown as BlogToolDeps;
   return { payload, codec, deps };
 };
 
@@ -718,6 +721,62 @@ describe('uploadMedia', () => {
       expect(result.content[0]?.text).toContain('上限 10MB');
       expect(payload.create).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('createUploadURL', () => {
+  it('issues a URL whose query params verify against the same secret, expiring ~10min from now', async () => {
+    const { deps } = createDeps();
+    const handlers = createBlogToolHandlers(deps);
+    const before = Math.floor(Date.now() / 1000);
+
+    const result = await handlers.createUploadURL({ filename: 'cover.png', alt: 'テスト画像' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]?.text ?? '{}') as { uploadURL: string; method: string; expiresAt: string; curlExample: string; note: string };
+    const url = new URL(parsed.uploadURL);
+    const userParam = url.searchParams.get('user');
+    const expParam = url.searchParams.get('exp');
+    const filenameParam = url.searchParams.get('filename');
+    const altParam = url.searchParams.get('alt');
+    const sigParam = url.searchParams.get('sig');
+
+    expect(userParam).toBe('1');
+    expect(filenameParam).toBe('cover.png');
+    expect(altParam).toBe('テスト画像');
+    expect(sigParam).not.toBeNull();
+    expect(expParam).not.toBeNull();
+
+    const exp = parseInt(expParam ?? '', 10);
+    expect(exp).toBeGreaterThanOrEqual(before + 600);
+    expect(exp).toBeLessThanOrEqual(before + 605);
+
+    const verifyResult = await verifyUploadURLParams(SIGNING_SECRET, { userID: 1, exp, filename: 'cover.png', alt: 'テスト画像' }, sigParam ?? '', before);
+    expect(verifyResult.isOk()).toBe(true);
+
+    expect(parsed.method).toBe('POST');
+    expect(new Date(parsed.expiresAt).getTime()).toBe(exp * 1000);
+    expect(parsed.curlExample).toContain(parsed.uploadURL);
+  });
+
+  it('rejects a filename with an unresolvable extension', async () => {
+    const { deps } = createDeps();
+    const handlers = createBlogToolHandlers(deps);
+
+    const result = await handlers.createUploadURL({ filename: 'cover.bmp', alt: 'テスト画像' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('MIME type を特定できません');
+  });
+
+  it('rejects an alt containing a half-width close paren', async () => {
+    const { deps } = createDeps();
+    const handlers = createBlogToolHandlers(deps);
+
+    const result = await handlers.createUploadURL({ filename: 'cover.png', alt: '図(A)B' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('）');
   });
 });
 

--- a/src/lib/mcp/upload-url/index.ts
+++ b/src/lib/mcp/upload-url/index.ts
@@ -1,0 +1,91 @@
+import { errAsync, fromPromise, okAsync } from 'neverthrow';
+
+import { UploadURLExpiredError, UploadURLSignatureError } from '../errors';
+
+import type { ResultAsync } from 'neverthrow';
+
+// Workers の isolate メモリ保護。media は画像/PDF 想定(旧 tools/index.ts から移設)。
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+const MIME_BY_EXT = {
+  avif: 'image/avif',
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+} satisfies Record<string, string>;
+
+type ImageExtension = keyof typeof MIME_BY_EXT;
+
+const isImageExtension = (ext: string): ext is ImageExtension => Object.hasOwn(MIME_BY_EXT, ext);
+
+export const resolveMimetypeFromFilename = (filename: string): string | undefined => {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  return isImageExtension(ext) ? MIME_BY_EXT[ext] : undefined;
+};
+
+// create_upload_url が発行してから POST /api/media-upload に届くまでの許容時間(秒)。
+export const UPLOAD_URL_TTL_SECONDS = 600;
+
+export type UploadURLParams = { userID: number; exp: number; filename: string; alt: string };
+
+// 署名対象の正規化メッセージ。先頭の "media-upload" は他用途の HMAC 署名との
+// ドメイン分離用 prefix(同じ secret を使う別の署名スキームと値が衝突しないようにする)。
+// filename / alt は可変長かつ利用者が自由に書ける文字列で、区切りに使う "\n" 自体を
+// 含み得る。生のまま連結すると、あるフィールドの末尾に "\n" を混ぜて次フィールドへ
+// 文字をはみ出させることで、別のパラメータ組が同一メッセージに潰れてしまう
+// (例: filename="a\nb", alt="c" と filename="a", alt="b\nc" が同じメッセージになる)。
+// encodeURIComponent は "\n" を "%0A" に、"%" 自身も "%25" にエスケープするため、
+// この変換は単射(injective)— 区切り文字の注入によるフィールド境界の押し出しを防ぐ。
+const buildCanonicalMessage = (params: UploadURLParams): string => `media-upload\n${params.userID}\n${params.exp}\n${encodeURIComponent(params.filename)}\n${encodeURIComponent(params.alt)}`;
+
+const textEncoder = new TextEncoder();
+
+// Web Crypto(globalThis.crypto.subtle)のみを使う — node:crypto は Cloudflare Workers
+// ランタイムに存在しないため、Node/Workers 両方で動く共通実装として避ける。
+const importHMACKey = (secret: string): Promise<CryptoKey> => globalThis.crypto.subtle.importKey('raw', textEncoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+
+export const signUploadURLParams = async (secret: string, params: UploadURLParams): Promise<string> => {
+  const key = await importHMACKey(secret);
+  const signature = await globalThis.crypto.subtle.sign('HMAC', key, textEncoder.encode(buildCanonicalMessage(params)));
+  return Buffer.from(signature).toString('hex');
+};
+
+// 16 進ペアの繰り返しのみ許容(大文字小文字は許容、空文字・奇数長は不可)。
+const HEX_STRING = /^(?:[0-9a-f]{2})+$/i;
+
+// hex 文字列 -> bytes は Buffer の 'hex' codec に任せる。ただし Buffer.from(x, 'hex')
+// は不正入力で throw せず黙って途中まで decode するため、事前の全文 regex 検証が必須
+// (不正は undefined = 署名不正として扱う。throw しない)。Uint8Array.from で包むのは
+// Buffer の基盤が ArrayBufferLike 型で crypto.subtle の BufferSource に直接渡せないため。
+const decodeHex = (hex: string): Uint8Array<ArrayBuffer> | undefined => (HEX_STRING.test(hex) ? Uint8Array.from(Buffer.from(hex, 'hex')) : undefined);
+
+const EXPIRED_MESSAGE = '署名付き upload URL の有効期限が切れています。create_upload_url で再発行してください。';
+const SIGNATURE_MESSAGE = '署名付き upload URL の署名が不正です。create_upload_url で再発行してください。';
+
+// exp 検証(期限切れは署名検証より先に弾く — spec 通りの順序)。
+const rejectIfExpired = (params: UploadURLParams, nowSeconds: number): ResultAsync<UploadURLParams, UploadURLExpiredError> =>
+  params.exp < nowSeconds ? errAsync(new UploadURLExpiredError(EXPIRED_MESSAGE)) : okAsync(params);
+
+// crypto.subtle.verify は定数時間比較を行う(sig 長が digest 長と異なる場合も
+// throw せず false を返す — decodeHex 済みの bytes をそのまま渡せば安全)。
+const verifySignatureBytes = async (secret: string, params: UploadURLParams, sigBytes: Uint8Array<ArrayBuffer>): Promise<boolean> => {
+  const key = await importHMACKey(secret);
+  return globalThis.crypto.subtle.verify('HMAC', key, sigBytes, textEncoder.encode(buildCanonicalMessage(params)));
+};
+
+// hex デコード(小関数)→ Web Crypto 検証(小関数)の合成。デコード失敗・検証失敗の
+// いずれも同一の UploadURLSignatureError に落とす(呼び出し側からは区別不要)。
+const verifySignature = (secret: string, params: UploadURLParams, sig: string): ResultAsync<void, UploadURLSignatureError> => {
+  const sigBytes = decodeHex(sig);
+  if (sigBytes === undefined) return errAsync(new UploadURLSignatureError(SIGNATURE_MESSAGE));
+  return fromPromise(verifySignatureBytes(secret, params, sigBytes), () => new UploadURLSignatureError(SIGNATURE_MESSAGE)).andThen((valid) =>
+    valid ? okAsync(undefined) : errAsync(new UploadURLSignatureError(SIGNATURE_MESSAGE)),
+  );
+};
+
+// 署名付き upload URL のパラメータを検証する。exp 切れを先に判定し(rejectIfExpired)、
+// 通過したもののみ署名検証(verifySignature)へ進む — 小関数の andThen 合成。
+export const verifyUploadURLParams = (secret: string, params: UploadURLParams, sig: string, nowSeconds: number): ResultAsync<void, UploadURLExpiredError | UploadURLSignatureError> =>
+  rejectIfExpired(params, nowSeconds).andThen(() => verifySignature(secret, params, sig));

--- a/src/lib/mcp/upload-url/upload-url.test.ts
+++ b/src/lib/mcp/upload-url/upload-url.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+
+import { UploadURLExpiredError, UploadURLSignatureError } from '../errors';
+
+import { resolveMimetypeFromFilename, signUploadURLParams, verifyUploadURLParams } from './index';
+
+import type { UploadURLParams } from './index';
+
+const SECRET = 'test-secret-value';
+const NOW = 1_700_000_000;
+
+const baseParams = (): UploadURLParams => ({ userID: 42, exp: NOW + 600, filename: 'cover.png', alt: 'テスト画像' });
+
+describe('signUploadURLParams / verifyUploadURLParams', () => {
+  it('round-trips: sign then verify succeeds', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+
+    const result = await verifyUploadURLParams(SECRET, params, sig, NOW);
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('produces a 64-char lowercase hex signature', async () => {
+    const sig = await signUploadURLParams(SECRET, baseParams());
+
+    expect(sig).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('round-trips multibyte (Japanese) alt', async () => {
+    const params = { ...baseParams(), alt: '桜と富士山の写真、とても美しい景色です' };
+    const sig = await signUploadURLParams(SECRET, params);
+
+    const result = await verifyUploadURLParams(SECRET, params, sig, NOW);
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('fails with UploadURLSignatureError when userID is tampered', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const tampered = { ...params, userID: params.userID + 1 };
+
+    const result = await verifyUploadURLParams(SECRET, tampered, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('fails with UploadURLSignatureError when exp is tampered', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const tampered = { ...params, exp: params.exp + 1 };
+
+    const result = await verifyUploadURLParams(SECRET, tampered, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('fails with UploadURLSignatureError when filename is tampered', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const tampered = { ...params, filename: 'evil.png' };
+
+    const result = await verifyUploadURLParams(SECRET, tampered, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('fails with UploadURLSignatureError when alt is tampered', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+    const tampered = { ...params, alt: '差し替えられた alt' };
+
+    const result = await verifyUploadURLParams(SECRET, tampered, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('fails with UploadURLSignatureError when secret differs', async () => {
+    const params = baseParams();
+    const sig = await signUploadURLParams(SECRET, params);
+
+    const result = await verifyUploadURLParams('a-different-secret', params, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('fails with UploadURLExpiredError when exp has passed', async () => {
+    const params = { ...baseParams(), exp: NOW - 1 };
+    const sig = await signUploadURLParams(SECRET, params);
+
+    const result = await verifyUploadURLParams(SECRET, params, sig, NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLExpiredError);
+  });
+
+  it('treats exp === nowSeconds as still valid (boundary is inclusive)', async () => {
+    const params = { ...baseParams(), exp: NOW };
+    const sig = await signUploadURLParams(SECRET, params);
+
+    const result = await verifyUploadURLParams(SECRET, params, sig, NOW);
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  it('is unambiguous under newline-boundary shift between filename and alt', async () => {
+    // filename="a\nb", alt="c" と filename="a", alt="b\nc" は、区切り文字をそのまま
+    // "\n" で連結すると同一メッセージに潰れてしまう組み合わせ(review 指摘のケース)。
+    // encodeURIComponent によるフィールドエンコードでこれが解消されていることを pin する。
+    const paramsA = { ...baseParams(), filename: 'a\nb', alt: 'c' };
+    const paramsB = { ...baseParams(), filename: 'a', alt: 'b\nc' };
+
+    const sigA = await signUploadURLParams(SECRET, paramsA);
+    const sigB = await signUploadURLParams(SECRET, paramsB);
+
+    expect(sigA).not.toBe(sigB);
+
+    const crossVerifyAWithB = await verifyUploadURLParams(SECRET, paramsB, sigA, NOW);
+    const crossVerifyBWithA = await verifyUploadURLParams(SECRET, paramsA, sigB, NOW);
+
+    expect(crossVerifyAWithB.isErr()).toBe(true);
+    expect(crossVerifyAWithB._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+    expect(crossVerifyBWithA.isErr()).toBe(true);
+    expect(crossVerifyBWithA._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+
+  it('checks expiry before signature (expired + tampered signature still reports expiry)', async () => {
+    const params = { ...baseParams(), exp: NOW - 1 };
+
+    const result = await verifyUploadURLParams(SECRET, params, 'not-a-real-signature', NOW);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(UploadURLExpiredError);
+  });
+
+  it('fails with UploadURLSignatureError (without throwing) for malformed hex signature', async () => {
+    const params = baseParams();
+
+    const oddLength = await verifyUploadURLParams(SECRET, params, 'abc', NOW);
+    const nonHex = await verifyUploadURLParams(SECRET, params, 'zz'.repeat(32), NOW);
+    const empty = await verifyUploadURLParams(SECRET, params, '', NOW);
+    const wrongLength = await verifyUploadURLParams(SECRET, params, 'ab'.repeat(16), NOW);
+
+    expect(oddLength.isErr()).toBe(true);
+    expect(oddLength._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+    expect(nonHex.isErr()).toBe(true);
+    expect(nonHex._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+    expect(empty.isErr()).toBe(true);
+    expect(empty._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+    expect(wrongLength.isErr()).toBe(true);
+    expect(wrongLength._unsafeUnwrapErr()).toBeInstanceOf(UploadURLSignatureError);
+  });
+});
+
+describe('resolveMimetypeFromFilename', () => {
+  it.each([
+    ['photo.jpg', 'image/jpeg'],
+    ['photo.JPG', 'image/jpeg'],
+    ['photo.jpeg', 'image/jpeg'],
+    ['photo.JPEG', 'image/jpeg'],
+    ['photo.png', 'image/png'],
+    ['photo.PNG', 'image/png'],
+    ['photo.webp', 'image/webp'],
+    ['photo.WEBP', 'image/webp'],
+    ['photo.gif', 'image/gif'],
+    ['photo.GIF', 'image/gif'],
+    ['photo.avif', 'image/avif'],
+    ['photo.AVIF', 'image/avif'],
+  ])('resolves %s -> %s', (filename, expected) => {
+    expect(resolveMimetypeFromFilename(filename)).toBe(expected);
+  });
+
+  it.each([['photo.bmp'], ['photo.tiff'], ['photo'], ['photo.']])('returns undefined for unknown/missing extension: %s', (filename) => {
+    expect(resolveMimetypeFromFilename(filename)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

ローカルの画像ファイルを MCP 経由で media にアップロードできるようにする。既存の `upload_media` は url / base64 のみで、base64 は LLM コンテキストを大きく消費するため、**HMAC 署名付き upload URL** 方式を追加した。

### フロー

1. MCP ツール `create_upload_url { filename, alt }` — alt(往復可能性)/ 画像拡張子を検証し、`{ userID, exp, filename, alt }` を HMAC-SHA256 で署名した TTL 10 分の URL + curl 例を返す
2. クライアント(Claude Code 等)が `curl --data-binary @<ローカルパス> '<URL>'` を実行
3. `POST /api/media-upload` が署名・期限・拡張子・10MB を検証し、署名内 userID として `payload.create`(`overrideAccess: false`)→ `{ id, placeholder, url }` を返す

### 実装ポイント

- **署名**: Web Crypto HMAC-SHA256(鍵 = PAYLOAD_SECRET)。正規化メッセージは `media-upload\n{userID}\n{exp}\n{filename}\n{alt}` をフィールド単位で `encodeURIComponent` して injective 化(改行注入によるフィールド境界ずらしを防止 — レビュー blocker 対応)
- **route**: Hono on Next(`handle(app)`)。`zValidator` でクエリ検証、**署名検証 middleware を `bodyLimit` より前に配置** — 無署名リクエストで body を buffering しない(順序自体が認可境界。レビュー major 対応、401-before-413 をテストで固定)
- **エラー整形**: `name` をリテラル型化した error union の exhaustive switch + 深さ上限付き再帰 cause walker(ValidationError → 400、それ以外 → 500)
- パス は意図的に `/api/mcp` の外(mcp-guard が公開側 404 遮断するため)。リプレイは TTL 内のみ・実害は media 重複作成に限定(設計上許容)

### レビュー

opus セキュリティレビュー 3 回(署名モジュール / route / whole-branch)+ sonnet レビュー 2 回を通過。指摘の blocker 1 件(正規化メッセージ曖昧性)・major 1 件(buffer-before-auth)は修正済みで、いずれも回帰テストで固定。

## テスト

- `pnpm test`: 1198 passed(新規 +58: upload-url 29 / tools 3 / route 25 / mcp route 1)
- `pnpm lint` / `pnpm typecheck`: clean
- デプロイ追加作業なし(新 secret / binding / migration なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)