### PR TITLE
fix(worker): keep GIF sources animated through the image transformer

### DIFF
--- a/worker/handlers/images/helpers.test.ts
+++ b/worker/handlers/images/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildFetchUrl, isAllowedUrl, isInternalAsset, isPayloadMediaPath } from './helpers';
+import { buildFetchUrl, isAllowedUrl, isGifSource, isInternalAsset, isPayloadMediaPath, resolveOutputFormat } from './helpers';
 
 const ORIGIN = 'https://booth2booth.com';
 
@@ -41,6 +41,47 @@ describe('buildFetchUrl', () => {
   it('returns full URL string for non-payload paths', () => {
     const url = new URL('/images/logo.png', ORIGIN);
     expect(buildFetchUrl(url, ORIGIN)).toBe(`${ORIGIN}/images/logo.png`);
+  });
+});
+
+describe('isGifSource', () => {
+  it('returns true for image/gif content type', () => {
+    expect(isGifSource('image/gif', '/api/media/file/anim')).toBe(true);
+  });
+
+  it('returns true for image/gif content type with parameters', () => {
+    expect(isGifSource('image/gif; charset=binary', '/api/media/file/anim')).toBe(true);
+  });
+
+  it('falls back to the .gif extension when content type is missing', () => {
+    expect(isGifSource(null, '/images/anim.gif')).toBe(true);
+    expect(isGifSource('application/octet-stream', '/images/anim.GIF')).toBe(true);
+  });
+
+  it('returns false for non-gif sources', () => {
+    expect(isGifSource('image/png', '/images/logo.png')).toBe(false);
+    expect(isGifSource(null, '/images/logo.png')).toBe(false);
+  });
+});
+
+describe('resolveOutputFormat', () => {
+  it('honors an explicit format over everything else', () => {
+    expect(resolveOutputFormat({ explicit: 'png', accept: 'image/avif,image/webp', isGif: true })).toBe('image/png');
+  });
+
+  it('keeps gif sources animated as webp when the client accepts webp', () => {
+    expect(resolveOutputFormat({ explicit: undefined, accept: 'image/avif,image/webp,*/*', isGif: true })).toBe('image/webp');
+  });
+
+  it('keeps gif sources as gif when the client does not accept webp', () => {
+    expect(resolveOutputFormat({ explicit: undefined, accept: 'image/avif,*/*', isGif: true })).toBe('image/gif');
+    expect(resolveOutputFormat({ explicit: undefined, accept: '', isGif: true })).toBe('image/gif');
+  });
+
+  it('negotiates avif > webp > jpeg for non-gif sources', () => {
+    expect(resolveOutputFormat({ explicit: undefined, accept: 'image/avif,image/webp', isGif: false })).toBe('image/avif');
+    expect(resolveOutputFormat({ explicit: undefined, accept: 'image/webp', isGif: false })).toBe('image/webp');
+    expect(resolveOutputFormat({ explicit: undefined, accept: '', isGif: false })).toBe('image/jpeg');
   });
 });
 

--- a/worker/handlers/images/helpers.ts
+++ b/worker/handlers/images/helpers.ts
@@ -20,3 +20,27 @@ export const buildFetchUrl = (url: URL, origin: string): string => {
 export const isInternalAsset = (url: URL, origin: string): boolean => {
   return url.origin === origin && !isPayloadMediaPath(url.pathname);
 };
+
+export const isGifSource = (contentType: string | null, pathname: string): boolean => {
+  if (contentType !== null && contentType.toLowerCase().startsWith('image/gif')) return true;
+  return pathname.toLowerCase().endsWith('.gif');
+};
+
+type ExplicitFormat = 'avif' | 'webp' | 'jpeg' | 'png' | 'gif';
+type OutputFormat = `image/${ExplicitFormat}`;
+
+type ResolveOutputFormatArgs = {
+  explicit: ExplicitFormat | undefined;
+  accept: string;
+  isGif: boolean;
+};
+
+// GIF は avif/jpeg に落とすとアニメーションが失われるため、アニメ保持可能な
+// webp(accept にあれば)/ gif に限定して交渉する。
+export const resolveOutputFormat = ({ explicit, accept, isGif }: ResolveOutputFormatArgs): OutputFormat => {
+  if (explicit !== undefined) return `image/${explicit}`;
+  if (isGif) return /image\/webp/.test(accept) ? 'image/webp' : 'image/gif';
+  if (/image\/avif/.test(accept)) return 'image/avif';
+  if (/image\/webp/.test(accept)) return 'image/webp';
+  return 'image/jpeg';
+};

--- a/worker/handlers/images/index.ts
+++ b/worker/handlers/images/index.ts
@@ -4,11 +4,11 @@ import z from 'zod';
 import { factory } from '../factory';
 
 import { fetchImage } from './fetchers';
-import { buildFetchUrl, isAllowedUrl } from './helpers';
+import { buildFetchUrl, isAllowedUrl, isGifSource, resolveOutputFormat } from './helpers';
 
 import type { FetchContext } from './fetchers';
 
-const Format = z.union([z.literal('avif'), z.literal('webp'), z.literal('jpeg'), z.literal('png')]);
+const Format = z.union([z.literal('avif'), z.literal('webp'), z.literal('jpeg'), z.literal('png'), z.literal('gif')]);
 
 const TransformOptions = z.object({
   url: z.string(),
@@ -24,7 +24,7 @@ const TransformOptions = z.object({
 
 type TransformOptionsType = z.infer<typeof TransformOptions>;
 
-const transformImage = async (images: NonNullable<Cloudflare.Env['IMAGES']>, body: ReadableStream<Uint8Array>, query: TransformOptionsType, accept: string) => {
+const transformImage = async (images: NonNullable<Cloudflare.Env['IMAGES']>, body: ReadableStream<Uint8Array>, query: TransformOptionsType, accept: string, isGif: boolean) => {
   const transform = await images
     .input(body)
     .transform({
@@ -43,10 +43,7 @@ const transformImage = async (images: NonNullable<Cloudflare.Env['IMAGES']>, bod
         return query.quality ?? query.q;
       },
       get format() {
-        if (query.format !== undefined) return `image/${query.format}` as const;
-        if (/image\/avif/.test(accept)) return 'image/avif' as const;
-        if (/image\/webp/.test(accept)) return 'image/webp' as const;
-        return 'image/jpeg' as const;
+        return resolveOutputFormat({ explicit: query.format, accept, isGif });
       },
     });
 
@@ -87,5 +84,7 @@ export const imageHandlers = factory.createHandlers(zValidator('query', Transfor
   const images = c.env.IMAGES;
   if (images === undefined) return c.json({ error: 'IMAGES binding unavailable' }, 500);
 
-  return transformImage(images, body, query, accept);
+  const isGif = isGifSource(sourceRes.headers.get('content-type'), url.pathname);
+
+  return transformImage(images, body, query, accept, isGif);
 });


### PR DESCRIPTION
## Summary

`/_next/image` の worker handler は format 交渉で常に avif/webp/jpeg に変換していたため、アニメ GIF が先頭フレームの静止画に潰れていた。GIF ソースを検出してアニメ保持可能な出力(animated WebP / GIF)に限定する。

## Changes

- **`helpers.ts`**: 純関数を 2 つ追加
  - `isGifSource(contentType, pathname)` — source response の content-type(`image/gif`、パラメータ付き可)で判定し、content-type が欠落/octet-stream の場合は `.gif` 拡張子にフォールバック
  - `resolveOutputFormat({ explicit, accept, isGif })` — handler の getter に埋まっていた format 交渉を抽出。GIF ソースは accept に webp があれば animated WebP、なければ GIF のまま。非 GIF は従来通り avif > webp > jpeg
- **`index.ts`**: fetch 済み response から `isGif` を判定して transform に配線。zod `Format` に `'gif'` を追加(明示指定でも GIF 出力可能に)
- **`helpers.test.ts`**: 8 テスト追加(GIF 判定 4 / format 交渉 4)

## Notes

- Cloudflare Images binding の `anim` オプションはデフォルト `true` のため、出力が gif/webp なら追加指定なしでアニメーションが保持される。修正が必要だったのは format 選択のみ
- animated AVIF 出力は Cloudflare Images 非対応のため、GIF ソースでは accept に avif があっても意図的にスキップ
- `app.ts` のキャッシュは既に `vary: ['Accept']` なので webp 対応/非対応クライアントで正しく別エントリになる
- 明示 `format` クエリは従来通り最優先(GIF ソースに `format=jpeg` を指定すれば静止画になる)

## Test plan

- [x] `pnpm vitest run worker` — 42/42 pass
- [x] `pnpm lint` / `pnpm typecheck` clean
- [ ] staging デプロイ後、アニメ GIF を `/_next/image?url=...` 経由で取得しアニメが残ることを実機確認(`IMAGES` binding がローカル preview に無いため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXAawEANgRWsUT376Xt2iz