### PR TITLE
docs(rules): PR #27 レビュー指摘を rules に永続化

### DIFF
--- a/.claude/rules/cross-module-sync-test.md
+++ b/.claude/rules/cross-module-sync-test.md
@@ -1,0 +1,28 @@
+# Cross-Module Constant Sync: Assert With a Test
+
+When two modules must keep a list/constant in 1:1 sync, a comment saying "keep in sync with X" is not enforcement. Export the canonical value from one side and assert equality in a test that imports both.
+
+## Pattern
+
+```typescript
+// side A (canonical or co-canonical) — export the list
+export const PRELOADED_LANGUAGE_KEYS = ['typescript', 'tsx', 'css', 'json', 'bash'] as const;
+
+// side B's test — import both, assert 1:1
+expect(Object.keys(CODE_LANGUAGES)).toEqual([...PRELOADED_LANGUAGE_KEYS]);
+```
+
+A hand-copied literal in the test (`toEqual(['typescript', ...])`) only pins one side — it does not fail when the *other* module drifts. The assertion must import from both modules.
+
+## When a Literal Cannot Be Derived
+
+Some values must stay literal for tooling (e.g. dynamic `import('@shikijs/langs/typescript')` paths must be literal for the bundler). In that case keep the literal AND the exported list adjacent in the same file with a comment binding them, and let the cross-module test cover the inter-module drift.
+
+## Known Sync Pairs in This Repo
+
+| Pair | Test |
+| --- | --- |
+| `CODE_LANGUAGES` (src/blocks/code) ↔ Shiki `PRELOADED_LANGUAGE_KEYS` (rich-text code highlighter) | `src/blocks/code/code.test.ts` |
+| `NodeTypes` union (rich-text converters) ↔ `renderBlock` branches (src/utils/lexical/to-markdown) | mirrored by hand — add branches to both when adding a block |
+
+Add new pairs to this table when you introduce one.

--- a/.claude/rules/markdown-fence-emission.md
+++ b/.claude/rules/markdown-fence-emission.md
@@ -1,0 +1,31 @@
+# Markdown Fence Emission
+
+Rules for any code path that wraps arbitrary content in Markdown ``` fences (llms.txt exporters, MCP `get_post`, block `jsx.export` converters).
+
+## Never Hardcode the Fence
+
+Content being wrapped may itself contain fence lines. A hardcoded ```` ``` ```` terminates early at the first embedded fence line and corrupts everything after it. Use `fenceForCode` from `src/utils/code-fence` — it returns a fence one backtick longer than the longest leading backtick run in the content (minimum 3), per CommonMark.
+
+```typescript
+// Correct
+import { fenceForCode } from '@/utils/code-fence'; // (path per caller)
+const fence = fenceForCode(code);
+return `${fence}${lang}\n${code}\n${fence}`;
+
+// Forbidden — breaks when code contains a ``` line
+return `\`\`\`${lang}\n${code}\n\`\`\``;
+```
+
+## Reject What Cannot Round-Trip — Never Corrupt Silently
+
+If the matching import path cannot parse a shape the export path can produce (e.g. lexical's regex-based `customStartRegex`/`customEndRegex` cannot match fence lengths, so 4+ backtick fences close early on the inner ``` line), the write path must **reject that shape explicitly with a recovery hint** instead of importing it corrupted.
+
+Precedent: `src/blocks/code/mcp-support` rejects 4+ backtick fences with 「admin から編集してください」 rather than silently truncating the code (PR #27 review).
+
+## Do Not Trust Premade Converters on Edge Cases
+
+Payload's premade/`@experimental` converters have shipped with real bugs (3.84.1 `CodeBlock` import corrupts a bare fence with single-line content into `"undefined<code>"` via a `'```' + undefined` string comparison). Before adopting one:
+
+- Execute the vendor converter directly against edge-case inputs (empty language, single line, adjacent fences) — do not reason from its source alone.
+- Pin the behavior you depend on with unit tests so a package upgrade that changes it fails loudly.
+- If it is buggy, replace it via `fieldOverrides.jsx` (keep the premade admin UI) rather than patching around it downstream.

--- a/.claude/rules/mcp-write-strict.md
+++ b/.claude/rules/mcp-write-strict.md
@@ -1,0 +1,25 @@
+# MCP Tools: Read-Normalize, Write-Strict
+
+Policy for the MCP blog tools (`src/lib/mcp`), established in PR #21 (media URL normalization) and reaffirmed in PR #27 (code fence language keys).
+
+## The Rule
+
+- **Read paths** (`get_post`, markdown export) may normalize representations to a canonical form (e.g. media URLs → `![media:<id>]` placeholders).
+- **Write paths** (`create_post` / `update_post` validation) must be strict: invalid or unsupported input is **rejected with an actionable recovery hint** — never silently converted, coerced, or dropped.
+
+## What a Recovery Hint Contains
+
+The error message is written for an LLM caller and must let it self-correct in one retry:
+
+1. What is wrong, in one sentence.
+2. The full list of valid options (e.g. 対応キー: `typescript / tsx / css / json / bash`).
+3. The offending line/fragment quoted verbatim (該当行: ...).
+4. The escape hatch, if one exists (キー省略も可 / admin から編集してください).
+
+## Why Not Silent Conversion
+
+Silent coercion (e.g. mapping an unknown fence language to plain text) loses information without telling the caller, and a later read-modify-write cycle bakes the loss in permanently. An explicit reject keeps the document unchanged and pushes the decision back to the caller. This was an explicit design decision (サイレント変換却下, PR #21) — do not "helpfully" soften a write-path validation into a conversion.
+
+## Where Validation Lives
+
+Per-block validation goes in that block's `mcp-support/` plugin (`McpBlockSupport.validateFences`), registered in `src/lib/mcp/markdown`. Convert upstream errors that would surface as opaque Payload `ValidationError`s (e.g. select-field option mismatches) into recovery hints **before** they reach Payload.


### PR DESCRIPTION
## 概要

PR #27(richtext codeblock)のコードレビューで CONFIRMED になった指摘のうち、一般化できる 3 つを `.claude/rules/` に永続化します。

## 追加ルール

1. **markdown-fence-emission.md** — 任意コンテンツを ``` フェンスで包む export の 3 則
   - フェンスをハードコードせず `fenceForCode`(src/utils/code-fence)で動的フェンス長に
   - import 側が round-trip できない形は silent 破壊せず recovery hint 付きで明示 reject
   - premade / experimental converter はエッジケースを実行して検証し、テストでピンする(3.84.1 CodeBlock の `undefined` バグが実例)
2. **mcp-write-strict.md** — read-normalize / write-strict 方針(PR #21 で確立、PR #27 で再確認 → ルール昇格)。recovery hint の 4 要素と validation の置き場所を明文化
3. **cross-module-sync-test.md** — 同期必須の定数対は「keep in sync」コメントでなく両モジュールを import するテストで突き合わせる。既知の同期ペア表つき

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011De8nzqn8LXFw9e1LNFiR9