### PR TITLE
feat(legal): admin に Live Preview と公開 URL リンクを追加

### DIFF
--- a/migrations/20260720_155000_legal_documents_autosave.ts
+++ b/migrations/20260720_155000_legal_documents_autosave.ts
@@ -1,0 +1,11 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-d1-sqlite'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.run(sql`ALTER TABLE \`_legal_documents_v\` ADD \`autosave\` integer;`)
+  await db.run(sql`CREATE INDEX \`_legal_documents_v_autosave_idx\` ON \`_legal_documents_v\` (\`autosave\`);`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.run(sql`DROP INDEX \`_legal_documents_v_autosave_idx\`;`)
+  await db.run(sql`ALTER TABLE \`_legal_documents_v\` DROP COLUMN \`autosave\`;`)
+}

--- a/migrations/index.ts
+++ b/migrations/index.ts
@@ -7,6 +7,7 @@ import * as migration_20260611_024807_drop_news_order from './20260611_024807_dr
 import * as migration_20260612_205858_blog_thumbnail from './20260612_205858_blog_thumbnail';
 import * as migration_20260613_200316_add_slug from './20260613_200316_add_slug';
 import * as migration_20260720_121330_legal_documents from './20260720_121330_legal_documents';
+import * as migration_20260720_155000_legal_documents_autosave from './20260720_155000_legal_documents_autosave';
 
 export const migrations = [
   {
@@ -53,5 +54,10 @@ export const migrations = [
     up: migration_20260720_121330_legal_documents.up,
     down: migration_20260720_121330_legal_documents.down,
     name: '20260720_121330_legal_documents'
+  },
+  {
+    up: migration_20260720_155000_legal_documents_autosave.up,
+    down: migration_20260720_155000_legal_documents_autosave.down,
+    name: '20260720_155000_legal_documents_autosave'
   },
 ];

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -32,6 +32,7 @@ import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c08
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { NewsPinnedStrip as NewsPinnedStrip_c20510d69b5fc73b97d88be1637109f9 } from '../../../components/admin/news-pinned-strip'
 import { GalleryHomeBadgeCell as GalleryHomeBadgeCell_b3739aae5a48e01dfb5feb0c6a004e84 } from '../../../components/admin/gallery-home-badge'
+import { LegalPublicURLField as LegalPublicURLField_8c0d031967b523c5f9568b804da19387 } from '../../../components/admin/legal-public-url'
 import { R2ClientUploadHandler as R2ClientUploadHandler_85cc02ed84006fcc91d3aff39dda669d } from '@payloadcms/storage-r2/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
@@ -71,6 +72,7 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "/components/admin/news-pinned-strip#NewsPinnedStrip": NewsPinnedStrip_c20510d69b5fc73b97d88be1637109f9,
   "/components/admin/gallery-home-badge#GalleryHomeBadgeCell": GalleryHomeBadgeCell_b3739aae5a48e01dfb5feb0c6a004e84,
+  "/components/admin/legal-public-url#LegalPublicURLField": LegalPublicURLField_8c0d031967b523c5f9568b804da19387,
   "@payloadcms/storage-r2/client#R2ClientUploadHandler": R2ClientUploadHandler_85cc02ed84006fcc91d3aff39dda669d,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/app/(site)/legal/preview/[id]/page.tsx
+++ b/src/app/(site)/legal/preview/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { draftMode } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import { LegalDocumentView } from '../../[slug]/_components/legal-document';
+
+import { LivePreviewListener } from '@components/live-preview';
+import { findLegalDocumentDraftById } from '@lib/payload/legal-documents';
+
+import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical';
+
+// Draft 専用 Live Preview ルート。常に動的 — autosave で流れる最新 draft を毎リクエスト
+// 再取得し、prerender もキャッシュもしない。secret ゲートの /next/preview handshake が
+// draft mode を有効化した後のみ到達可能で、そうでなければ 404(draft を漏らさない)。
+export const dynamic = 'force-dynamic';
+
+type Params = Promise<{ id: string }>;
+
+type Props = {
+  params: Params;
+};
+
+const LegalPreviewPage = async ({ params }: Props) => {
+  const { isEnabled } = await draftMode();
+  if (!isEnabled) return notFound();
+
+  const { id } = await params;
+  const doc = await findLegalDocumentDraftById(id);
+  if (doc === undefined) return notFound();
+
+  return (
+    <>
+      <LivePreviewListener />
+      <LegalDocumentView title={doc.title} effectiveAt={doc.effectiveAt} body={doc.body as unknown as SerializedEditorState} />
+    </>
+  );
+};
+
+export default LegalPreviewPage;

--- a/src/app/next/preview/allowed-paths.test.ts
+++ b/src/app/next/preview/allowed-paths.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedPreviewPath } from './allowed-paths';
+
+describe('isAllowedPreviewPath', () => {
+  it('各 previewable collection の draft ルートを許可する', () => {
+    expect(isAllowedPreviewPath('/news/preview/5')).toBe(true);
+    expect(isAllowedPreviewPath('/works/preview/12')).toBe(true);
+    expect(isAllowedPreviewPath('/blog/preview/3')).toBe(true);
+    expect(isAllowedPreviewPath('/gallery/preview')).toBe(true);
+    expect(isAllowedPreviewPath('/log/preview')).toBe(true);
+    expect(isAllowedPreviewPath('/legal/preview/1')).toBe(true);
+  });
+
+  it('open-redirect(protocol-relative URL)を拒否する', () => {
+    expect(isAllowedPreviewPath('//evil.com')).toBe(false);
+    expect(isAllowedPreviewPath('https://evil.com/legal/preview/1')).toBe(false);
+  });
+
+  it('preview 接頭辞に合致しないパスを拒否する', () => {
+    expect(isAllowedPreviewPath('/legal')).toBe(false);
+    expect(isAllowedPreviewPath('/legal/terms')).toBe(false);
+    expect(isAllowedPreviewPath('/admin')).toBe(false);
+    expect(isAllowedPreviewPath(null)).toBe(false);
+  });
+});

--- a/src/app/next/preview/allowed-paths.ts
+++ b/src/app/next/preview/allowed-paths.ts
@@ -1,0 +1,13 @@
+// Allowlist of preview-route prefixes the /next/preview handshake may redirect to.
+// A bare `startsWith('/')` would let protocol-relative URLs like `//evil.com`
+// through and turn the handshake into an open redirect, so every entry pins a
+// concrete `/<slug>/preview` prefix. Detail collections carry a trailing id
+// segment (`/works/preview/<id>`, `/legal/preview/<id>`); aggregate previews
+// (gallery, logs) have none.
+//
+// Keep in sync with the `draftPreviewRoute` buildPath prefixes in
+// payload.config.ts — adding a previewable collection means adding it BOTH there
+// and here (forgetting here makes the iframe 400).
+export const PREVIEW_PATH_PREFIXES = ['/news/preview/', '/works/preview/', '/blog/preview/', '/gallery/preview', '/log/preview', '/legal/preview/'] as const;
+
+export const isAllowedPreviewPath = (path: string | null): path is string => path !== null && PREVIEW_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));

--- a/src/app/next/preview/route.ts
+++ b/src/app/next/preview/route.ts
@@ -4,14 +4,7 @@ import { redirect } from 'next/navigation';
 
 import { getPayloadClient } from '@lib/payload/client';
 
-// Allowlist of preview-route prefixes this handshake is permitted to redirect to.
-// A bare `startsWith('/')` would let protocol-relative URLs like `//evil.com`
-// through and turn this into an open redirect, so every entry pins a concrete
-// `/<slug>/preview` prefix. Detail collections carry a trailing id segment
-// (`/works/preview/<id>`); aggregate previews (gallery, logs) have none.
-const PREVIEW_PATH_PREFIXES = ['/news/preview/', '/works/preview/', '/blog/preview/', '/gallery/preview', '/log/preview'] as const;
-
-const isAllowedPreviewPath = (path: string | null): path is string => path !== null && PREVIEW_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+import { isAllowedPreviewPath } from './allowed-paths';
 
 // Payload Live Preview handshake (official draft-mode pattern). The CMS iframe
 // points here with `path` + `previewSecret`; this route verifies the secret,

--- a/src/collections/legal-documents.test.ts
+++ b/src/collections/legal-documents.test.ts
@@ -20,12 +20,12 @@ describe('LegalDocuments', () => {
     expect(callRead({ id: 1 })).toBe(true);
   });
 
-  it('draft を有効にしている', () => {
-    expect(LegalDocuments.versions).toEqual({ drafts: true });
+  it('draft + autosave を有効にしている(Live Preview リアルタイム反映用)', () => {
+    expect(LegalDocuments.versions).toEqual({ drafts: { autosave: { interval: 375 } } });
   });
 
-  it('slug / title / effectiveAt / body を持つ', () => {
+  it('slug / title / effectiveAt / body + 公開 URL の ui フィールドを持つ', () => {
     const names = LegalDocuments.fields.map((field) => ('name' in field ? field.name : undefined));
-    expect(names).toEqual(['slug', 'title', 'effectiveAt', 'body']);
+    expect(names).toEqual(['slug', 'title', 'effectiveAt', 'body', 'publicURL']);
   });
 });

--- a/src/collections/legal-documents.ts
+++ b/src/collections/legal-documents.ts
@@ -25,9 +25,9 @@ export const LegalDocuments = {
     update: ({ req: { user } }) => user !== null,
     delete: ({ req: { user } }) => user !== null,
   },
-  // autosave は付けない。法務文書は書きながら見た目を確認するものではなく、下書きで改訂を
-  // 用意して施行日に publish する運用のため、素の drafts で足りる。
-  versions: { drafts: true },
+  // Live Preview を real time 反映させるため autosave を有効化(news/works/blog と同じ)。
+  // draft edits をストリームし、preview ルートの RefreshRouteOnSave が最新 draft を再取得する。
+  versions: { drafts: { autosave: { interval: 375 } } },
   hooks: {
     afterChange: [revalidateLegalDocuments.afterChange],
     afterDelete: [revalidateLegalDocuments.afterDelete],
@@ -58,6 +58,18 @@ export const LegalDocuments = {
       label: '本文',
       type: 'richText',
       required: true,
+    },
+    {
+      // 編集中の slug から公開 URL(/legal/{slug})をサイドバーにリンク表示する UI フィールド。
+      // 販売ページに貼る URL をここからコピーできる。スキーマには載らない(type: 'ui')。
+      name: 'publicURL',
+      type: 'ui',
+      admin: {
+        position: 'sidebar',
+        components: {
+          Field: '/components/admin/legal-public-url#LegalPublicURLField',
+        },
+      },
     },
   ],
 } satisfies CollectionConfig;

--- a/src/components/admin/legal-public-url/index.tsx
+++ b/src/components/admin/legal-public-url/index.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useField } from '@payloadcms/ui';
+
+import { LegalPublicURLView } from './view';
+
+// legal-documents 編集画面のサイドバーに刺さる `ui` フィールド。編集中の slug を
+// useField で購読し、公開 URL リンクを描画する(表示ロジックは LegalPublicURLView)。
+// admin と site は同一オリジンなので base は window.location.origin を使う — stg admin なら
+// stg URL、prod admin なら prod URL が自然に出る。SSR 時は origin 空でプレースホルダになる。
+export const LegalPublicURLField = () => {
+  const { value } = useField<string>({ path: 'slug' });
+  const origin = typeof window === 'undefined' ? '' : window.location.origin;
+
+  return <LegalPublicURLView slug={typeof value === 'string' ? value : ''} origin={origin} />;
+};

--- a/src/components/admin/legal-public-url/legal-public-url.test.tsx
+++ b/src/components/admin/legal-public-url/legal-public-url.test.tsx
@@ -1,0 +1,27 @@
+import { render } from 'vitest-browser-react';
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+
+import { LegalPublicURLView } from './view';
+
+describe('LegalPublicURLView', () => {
+  it('slug があれば {origin}/legal/{slug} をリンクで表示する', async () => {
+    await render(<LegalPublicURLView slug="terms" origin="https://napochaan.com" />);
+
+    const link = page.getByRole('link', { name: 'https://napochaan.com/legal/terms' });
+    await expect.element(link).toHaveAttribute('href', 'https://napochaan.com/legal/terms');
+  });
+
+  it('別オリジンでもそのまま反映する(現環境の base を使う想定)', async () => {
+    await render(<LegalPublicURLView slug="disclaimer" origin="https://stg.napochaan.com" />);
+
+    await expect.element(page.getByRole('link', { name: 'https://stg.napochaan.com/legal/disclaimer' })).toBeInTheDocument();
+  });
+
+  it('slug が空ならリンクを出さずプレースホルダ文言を表示する', async () => {
+    await render(<LegalPublicURLView slug="" origin="https://napochaan.com" />);
+
+    await expect.element(page.getByText('slug を入力すると公開 URL が表示されます')).toBeInTheDocument();
+    await expect.element(page.getByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/admin/legal-public-url/view.tsx
+++ b/src/components/admin/legal-public-url/view.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  slug: string;
+  origin: string;
+};
+
+// admin サイドバーに公開 URL({origin}/legal/{slug})をクリック可能リンクで表示する純粋
+// コンポーネント。origin は現環境の window.location.origin(admin と site は同一オリジン)。
+// slug 未入力時はリンクを出さずプレースホルダ文言のみ。データ取得は wrapper(index.tsx)側。
+export const LegalPublicURLView = ({ slug, origin }: Props) => {
+  if (slug === '') {
+    return <p className="field-description">slug を入力すると公開 URL が表示されます。</p>;
+  }
+
+  const href = `${origin}/legal/${slug}`;
+
+  return (
+    <div>
+      <p className="field-label">公開 URL</p>
+      <a href={href} target="_blank" rel="noreferrer">
+        {href}
+      </a>
+    </div>
+  );
+};

--- a/src/lib/payload/legal-documents/index.ts
+++ b/src/lib/payload/legal-documents/index.ts
@@ -37,3 +37,24 @@ export const findLegalDocumentBySlug = async (slug: string): Promise<LegalDocume
 
   return fetchLegalDocumentBySlug(slug);
 };
+
+// Draft パスは意図的に uncached(unstable_cache で包まない)で、draft: true により
+// _status を問わず最新 draft を返す。secret ゲート済みの preview ルート
+// (/legal/preview/{id})からのみ到達するため、公開側に draft が漏れることはない。
+export const findLegalDocumentDraftById = async (id: string): Promise<LegalDocument | undefined> => {
+  if (isBuildPhase()) return undefined;
+
+  const payload = await getPayloadClient();
+  const result = await payload.find({
+    collection: 'legal-documents',
+    where: { id: { equals: id } },
+    draft: true,
+    overrideAccess: true,
+    limit: 1,
+  });
+
+  const [doc] = result.docs;
+  if (doc === undefined) return undefined;
+
+  return doc;
+};

--- a/src/lib/payload/legal-documents/legal-documents.test.ts
+++ b/src/lib/payload/legal-documents/legal-documents.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { findLegalDocumentBySlug } from '.';
+import { findLegalDocumentBySlug, findLegalDocumentDraftById } from '.';
 
 const find = vi.fn();
 
@@ -42,5 +42,39 @@ describe('findLegalDocumentBySlug', () => {
     find.mockResolvedValue({ docs: [{ id: 1, slug: 'terms', title: '利用規約' }] });
 
     await expect(findLegalDocumentBySlug('terms')).resolves.toEqual({ id: 1, slug: 'terms', title: '利用規約' });
+  });
+});
+
+describe('findLegalDocumentDraftById', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('draft:true / overrideAccess で id 一致の最新 draft を引く(published フィルタなし)', async () => {
+    find.mockResolvedValue({ docs: [{ id: 3, slug: 'terms', _status: 'draft' }] });
+
+    await findLegalDocumentDraftById('3');
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'legal-documents',
+        where: { id: { equals: '3' } },
+        draft: true,
+        overrideAccess: true,
+        limit: 1,
+      }),
+    );
+  });
+
+  it('該当が無ければ undefined を返す', async () => {
+    find.mockResolvedValue({ docs: [] });
+
+    await expect(findLegalDocumentDraftById('999')).resolves.toBeUndefined();
+  });
+
+  it('draft を uncached で返す(published でない doc も返る)', async () => {
+    find.mockResolvedValue({ docs: [{ id: 3, slug: 'terms', _status: 'draft', title: '改訂中' }] });
+
+    await expect(findLegalDocumentDraftById('3')).resolves.toEqual({ id: 3, slug: 'terms', _status: 'draft', title: '改訂中' });
   });
 });

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -139,8 +139,13 @@ export default buildConfig({
           previewSecret: cfEnv.PREVIEW_SECRET ?? '',
           buildPath: () => '/log/preview',
         }),
+        draftPreviewRoute({
+          slug: 'legal-documents',
+          previewSecret: cfEnv.PREVIEW_SECRET ?? '',
+          buildPath: (data) => `/legal/preview/${data.id}`,
+        }),
       ]),
-      collections: ['news', 'works', 'blog', 'gallery', 'logs'],
+      collections: ['news', 'works', 'blog', 'gallery', 'logs', 'legal-documents'],
     },
     get autoLogin() {
       if (process.env.NODE_ENV !== 'development') return false;


### PR DESCRIPTION
## 概要

legal-documents の admin 編集体験を強化する。PR #32(法務文書ページ)の follow-up。

1. **Live Preview**(autosave 付き)— 編集中の draft を admin の iframe でリアルタイム確認
2. **公開 URL リンク** — サイドバーに `{現環境origin}/legal/{slug}` を表示(販売ページに貼る URL をコピーできる)

brainstorming では preview 非採用としていたが、本人要望で追加。

## 変更点

| 領域 | 内容 |
| --- | --- |
| collection | `versions` を `{ drafts: { autosave: { interval: 375 } } }` に + `publicURL` の `ui` フィールド |
| migration | `_legal_documents_v` に `autosave` カラム + index(autosave はスキーマ変更を伴う) |
| preview ルート | `/legal/preview/[id]`(`force-dynamic` + draftMode ガード + `findLegalDocumentDraftById` + `LivePreviewListener`)。news preview をミラー |
| loader | `findLegalDocumentDraftById`(uncached / draft:true / overrideAccess) |
| admin コンポーネント | `LegalPublicURLField`(`useField` で slug 購読)+ 純粋 View(props で分離しテスト可能に) |
| payload.config | preview resolver + `livePreview.collections` に `legal-documents` 追加 |

## 設計メモ

- 公開 URL の base は client 側 `window.location.origin`。admin と site は同一オリジンなので stg admin→stg URL / prod admin→prod URL が自然に出る。
- 公開 URL コンポーネントは「純粋 View(browser test 対象)」+「`useField` wrapper(実 admin で確認)」に分離。
- Payload CLI がこの環境でハングしたため migration は手書き。CI(`deploy:database:staging` / production)が remote binding 経由で正規適用する。
- sitemap.ts / llms.txt は不変(preview ルートは非索引)。

## テスト

- loader draft 3 + 公開 URL View 3 + collection 更新、全体 1422 pass / lint / typecheck clean
- 実 admin(Live Preview iframe / サイドバーリンク)は dev サーバー起動が必要なため本人確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
