### PR TITLE
fix(cls): stop the boot overlay and hero scramble from accruing layout shift

### DIFF
--- a/src/components/echo-text/echo-text.test.tsx
+++ b/src/components/echo-text/echo-text.test.tsx
@@ -2,7 +2,17 @@ import { render } from 'vitest-browser-react';
 import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 
+import { BootStatusProvider } from '@components/boot-status';
+
 import { EchoText } from './index';
+
+// Isolated boot phase: the store observes the injected element, so removing the
+// class here triggers bootReady (and the decode scramble) for this tree only.
+const makeBootTarget = () => {
+  const target = document.createElement('div');
+  target.classList.add('boot');
+  return target;
+};
 
 describe('EchoText', () => {
   it('renders the wordmark with an accessible label', async () => {
@@ -21,5 +31,28 @@ describe('EchoText', () => {
   it('renders a compact size variant', async () => {
     const { container } = await render(<EchoText size="compact">napochaan</EchoText>);
     expect(container.querySelector('[data-size="compact"]')).not.toBeNull();
+  });
+
+  it('locks the scramble box width during decode and releases it afterwards', async () => {
+    // The scramble glyphs vary in advance width, so without a locked box every
+    // refresh would push the trailing red dot (and the centered line) around —
+    // each nudge counting toward CLS. The decode must pin the box's inline size
+    // for the tween's lifetime and clear it once the wordmark settles.
+    const target = makeBootTarget();
+    const { container } = await render(
+      <BootStatusProvider target={target}>
+        <EchoText>napochaan</EchoText>
+      </BootStatusProvider>,
+    );
+    const scramble = container.querySelector('[data-scramble]');
+    if (!(scramble instanceof HTMLElement)) throw new Error('scramble span not found');
+    expect(scramble.style.width).toBe('');
+
+    target.classList.remove('boot');
+
+    // Locked while the decode tween runs...
+    await expect.poll(() => scramble.style.width, { timeout: 3000 }).toMatch(/px$/);
+    // ...and released when it completes (DURATION 1.1s + revealDelay).
+    await expect.poll(() => scramble.style.width, { timeout: 6000 }).toBe('');
   });
 });

--- a/src/components/echo-text/index.tsx
+++ b/src/components/echo-text/index.tsx
@@ -29,13 +29,28 @@ export const EchoText = ({ children, size = 'hero' }: Props) => {
 
   const decode = () => {
     if (prefersReducedMotion()) return;
+    const el = fillRef.current;
+    if (el === null) return;
+    // The scramble glyphs vary in advance width, so the span's inline size
+    // jitters on every refresh — nudging the trailing red dot (and the centered
+    // line box) each tick, and every nudge counts toward CLS (this was the
+    // page's dominant layout-shift source). Pin the box to the settled wordmark
+    // width for the tween's lifetime so the jitter stays inside; the momentary
+    // overflow of a wide glyph reads as part of the glitch. `overwrite` kills a
+    // still-running decode on hover re-entry so its clearProps can't unlock the
+    // box mid-scramble.
+    gsap.set(el, { display: 'inline-block', width: el.offsetWidth });
     // revealDelay holds the full scramble before decoding; low speed keeps the
     // glyph refresh chunky (digital) rather than a 60fps blur; tweenLength off
     // since the word length never changes.
-    gsap.to(fillRef.current, {
+    gsap.to(el, {
       duration: DURATION,
       ease: 'none',
+      overwrite: true,
       scrambleText: { text: children, chars: CHARS, speed: 0.45, revealDelay: 0.35, tweenLength: false },
+      onComplete: () => {
+        gsap.set(el, { clearProps: 'display,width' });
+      },
     });
   };
 
@@ -61,7 +76,9 @@ export const EchoText = ({ children, size = 'hero' }: Props) => {
         {children}
       </span>
       <span aria-hidden className={styles.fill}>
-        <span ref={fillRef}>{children}</span>
+        <span ref={fillRef} data-scramble>
+          {children}
+        </span>
         <span className={styles.red}>.</span>
       </span>
     </span>

--- a/src/components/loading-overlay/boot-question/boot-question.test.tsx
+++ b/src/components/loading-overlay/boot-question/boot-question.test.tsx
@@ -1,8 +1,18 @@
 import { render } from 'vitest-browser-react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { BootStatusProvider } from '@components/boot-status';
+
 import { BootQuestion, nextIndex, shuffle } from './index';
 import { QUESTIONS } from '../questions';
+
+// Isolated boot phase per test: the store observes the injected element instead
+// of <html>, so removing the class here ends the boot for this tree only.
+const makeBootTarget = () => {
+  const target = document.createElement('div');
+  target.classList.add('boot');
+  return target;
+};
 
 // Deterministic stand-in for Math.random: yields the queued values in order,
 // then 0. Mutable cursor lives in a const object (no `let`), matching the
@@ -62,10 +72,54 @@ describe('BootQuestion', () => {
       dispatchEvent: () => false,
     });
 
-    const screen = await render(<BootQuestion />);
+    // The island only animates during the boot phase.
+    const screen = await render(
+      <BootStatusProvider target={makeBootTarget()}>
+        <BootQuestion />
+      </BootStatusProvider>,
+    );
     const [first] = QUESTIONS;
     await expect.element(screen.getByText(first)).toBeInTheDocument();
 
     vi.restoreAllMocks();
+  });
+});
+
+describe('BootQuestion boot gating', () => {
+  // The island lives inside the boot overlay, which is visibility:hidden once
+  // `html.boot` drops — but the component itself stays mounted forever. Without
+  // gating, the typewriter keeps mutating layout (and burning timers) behind an
+  // invisible overlay, and every keystroke still counts toward CLS.
+
+  const typedLength = (root: HTMLElement) => (root.textContent ?? '').length;
+
+  it('types while the boot phase is active', async () => {
+    const screen = await render(
+      <BootStatusProvider target={makeBootTarget()}>
+        <BootQuestion />
+      </BootStatusProvider>,
+    );
+
+    await expect.poll(() => typedLength(screen.container), { timeout: 5000 }).toBeGreaterThan(2);
+  });
+
+  it('freezes the typewriter once the boot phase ends', async () => {
+    const target = makeBootTarget();
+    const screen = await render(
+      <BootStatusProvider target={target}>
+        <BootQuestion />
+      </BootStatusProvider>,
+    );
+    await expect.poll(() => typedLength(screen.container), { timeout: 5000 }).toBeGreaterThan(2);
+
+    target.classList.remove('boot');
+    // Let any in-flight keystroke land, then take the frozen baseline.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const frozen = screen.container.textContent;
+
+    // Negative assertion: settle window long enough for several keystrokes
+    // (speed=46ms) and a HOLD_MS advance to have fired if gating were broken.
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    expect(screen.container.textContent).toBe(frozen);
   });
 });

--- a/src/components/loading-overlay/boot-question/index.tsx
+++ b/src/components/loading-overlay/boot-question/index.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { useBootReady } from '@components/boot-status';
 import { usePrefersReducedMotion } from '@hooks/use-prefers-reduced-motion';
 import { useTypewriter } from '@hooks/use-typewriter';
 
@@ -30,13 +31,17 @@ const HOLD_MS = 1800;
 
 type LineProps = {
   text: string;
+  active: boolean;
   onDone: () => void;
 };
 
 // One prompt's keystrokes. Remounted (via key) per cycle so the hook's controller
-// restarts cleanly on the next prompt.
-const Line = ({ text, onDone }: LineProps) => {
-  const { displayText, isDone } = useTypewriter(text);
+// restarts cleanly on the next prompt. `active` gates ALL motion: when the boot
+// phase ends the overlay goes visibility:hidden but this island stays mounted, so
+// without the gate the typewriter would keep shifting (invisible) layout forever —
+// each keystroke counted toward CLS and kept a timer chain alive.
+const Line = ({ text, active, onDone }: LineProps) => {
+  const { displayText, isDone } = useTypewriter(text, { startWhen: active });
   const reduced = usePrefersReducedMotion();
 
   useEffect(() => {
@@ -44,10 +49,11 @@ const Line = ({ text, onDone }: LineProps) => {
     // prompt finishes typing, wait, then advance. Pure animation pacing, not state
     // sync. Under reduced motion the hook jumps to the full text immediately, and
     // we skip the timer so the cycle rests on a single prompt (no looping motion).
-    if (!isDone || reduced) return undefined;
+    // Once boot ends (`active` false) the cycle freezes on the current prompt.
+    if (!isDone || reduced || !active) return undefined;
     const timer = setTimeout(onDone, HOLD_MS);
     return () => clearTimeout(timer);
-  }, [isDone, reduced, onDone]);
+  }, [isDone, reduced, active, onDone]);
 
   return (
     <>
@@ -65,6 +71,11 @@ export const BootQuestion = () => {
   const [index, setIndex] = useState(0);
   const advance = useCallback(() => setIndex((current) => nextIndex(current, order.length)), [order.length]);
   const text = order[index] ?? QUESTIONS[0];
+  // The shared boot store settles ready:true when the Typekit loader removes
+  // `boot` from <html> — that removal ends the show (server snapshot is
+  // ready:false, so hydration starts in the active state, matching the SSR'd
+  // boot class).
+  const bootReady = useBootReady();
 
-  return <Line key={index} text={text} onDone={advance} />;
+  return <Line key={index} text={text} active={!bootReady} onDone={advance} />;
 };

--- a/src/components/loading-overlay/styles.css.ts
+++ b/src/components/loading-overlay/styles.css.ts
@@ -22,14 +22,23 @@ export const root = css({
   // frame, with the same blue + white-mono voice as the TypographyBand.
   bg: 'accent.solid',
   opacity: '[0]',
+  // `visibility: hidden` at rest removes the overlay from painting entirely once
+  // the fade ends. This matters beyond hygiene: layout shifts of PAINTED content
+  // count toward CLS even at opacity 0 (and even under an opaque cover), so the
+  // typewriter island was accruing CLS forever behind the invisible overlay.
+  // Transitioning visibility alongside opacity keeps the element visible for the
+  // whole fade (visible→hidden flips only at transition end per spec) and shows
+  // it instantly on the way in.
+  visibility: 'hidden',
   pointerEvents: 'none',
-  transitionProperty: '[opacity]',
+  transitionProperty: '[opacity, visibility]',
   transitionDuration: 'slow',
   // `bootAutoDismiss` (see global.css) is a no-JS fail-safe: if the Typekit loader
   // never removes `boot`, this fades the overlay out after ~7s so content is always
-  // reachable. When the loader DOES remove `boot`, this rule stops applying and the
-  // overlay fades via the opacity transition above instead.
-  'html.boot &': { opacity: '[1]', pointerEvents: 'auto', animation: '[bootAutoDismiss 7s linear forwards]' },
+  // reachable (its 100% frame also lands on visibility:hidden). When the loader
+  // DOES remove `boot`, this rule stops applying and the overlay fades via the
+  // opacity+visibility transition above instead.
+  'html.boot &': { opacity: '[1]', visibility: 'visible', pointerEvents: 'auto', animation: '[bootAutoDismiss 7s linear forwards]' },
 });
 
 // Left-aligned mono console block, centered as a unit. Fixed-ish width gives the


### PR DESCRIPTION
## Summary

Lab CLS sat at 0.10–0.12, at/over the Core Web Vitals "good" threshold. Layout-shift source attribution (PerformanceObserver with `sources`) traced nearly all of it to two animations — not fonts, and not the `bootAutoDismiss` keyframes DevTools heuristically blamed:

1. **EchoText scramble decode** — scramble glyphs vary in advance width, so every ~110ms refresh pushed the trailing red `.` (and the centered hero line) around, ~0.02 per nudge, repeating on every hover re-decode. The decode now pins the scramble span to its settled width for the tween's lifetime (cleared on complete; `overwrite: true` guards hover re-entry).
2. **Boot overlay afterlife** — after its fade the overlay stayed at `opacity: 0`, which still paints, while the BootQuestion typewriter cycled prompts forever; each invisible keystroke counted toward CLS and kept timers alive. The overlay now transitions to `visibility: hidden` at fade end (visually identical fade), and BootQuestion freezes its cycle when the shared boot store settles (`@components/boot-status` reused — no new observer).

## Verification

Production build (`next build` + `next start`), 8s observation window, two samples:

| | before | after |
|---|---|---|
| CLS | 0.122 | **0.012** |
| max single shift | 0.0244 | 0.006 |

Tests: 15 passing across echo-text / loading-overlay (freeze gating pinned with a settle-window negative assertion; width lock pinned via `[data-scramble]` style polling). `pnpm lint` / `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7Jcn74YdSrvxtkBt6GTAt