### PR TITLE
docs(skills): add edge-compression and CLS debugging skills

### DIFF
--- a/.claude/skills/debugging-cumulative-layout-shift/SKILL.md
+++ b/.claude/skills/debugging-cumulative-layout-shift/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: debugging-cumulative-layout-shift
+description: Use when CLS is at or over 0.1, when DevTools CLSCulprits reports shifts with "no potential root causes identified" or blames a non-composited animation, or when many tiny layout shifts accumulate over seconds.
+---
+
+# Debugging Cumulative Layout Shift
+
+## Overview
+
+DevTools' CLS attribution is a pattern-matching heuristic — it only recognizes font swaps, unsized media, and CSS animations. JS-driven text mutation (typewriters, GSAP ScrambleText) comes back "no root causes identified", and the animation it DOES blame may be a bystander. **Get ground truth from `layout-shift` entry sources, never from the insight.**
+
+## What counts toward CLS (the exact paint rules)
+
+| State of the shifted content | Counts? |
+|---|---|
+| Inside a `position: fixed` overlay | **YES** — fixed exempts nothing; children that move are counted |
+| At `opacity: 0` | **YES** — opacity-0 content is still painted; if its geometry moves, it counts |
+| Under an opaque covering element | **YES** — being visually covered is not an exemption |
+| At `visibility: hidden` | **NO** — not painted, the only practical exemption |
+| Moved via `transform` | NO — transforms don't shift layout |
+
+The killer pattern this repo hit: an overlay faded to `opacity: 0` but stayed mounted while a typewriter kept cycling inside it — **invisible keystrokes accrued CLS forever**. Fix shape: transition the overlay to `visibility: hidden` at fade end (`transition: opacity, visibility` — visible→hidden flips at transition END, so the fade looks identical) AND stop the animation loop (here: gate on `useBootReady()` from `@components/boot-status` — reuse that store, don't write a new `<html>` class observer).
+
+## Ground-truth measurement
+
+```js
+// Run on the live page (chrome-devtools evaluate_script; for Access-gated staging
+// use claude-in-chrome javascript_tool with the user's session).
+const entries = [];
+const po = new PerformanceObserver((l) => entries.push(...l.getEntries()));
+po.observe({ type: 'layout-shift', buffered: true });
+await new Promise((r) => setTimeout(r, 8000));
+po.disconnect();
+entries.filter((e) => !e.hadRecentInput).map((e) => ({
+  t: Math.round(e.startTime),
+  score: +e.value.toFixed(4),
+  // Text nodes have no tagName — climb to parentElement or you'll log "unknown".
+  nodes: (e.sources ?? []).map((s) => (s.node?.nodeType === 3 ? s.node.parentElement : s.node)),
+}));
+```
+
+Read the timing fingerprint: dozens of evenly-spaced tiny shifts ≈ per-tick JS text mutation; one or two large discrete shifts ≈ font swap or content insertion.
+
+## Scramble/typewriter fix pattern
+
+Glyphs have varying advance widths, so every scramble refresh nudges following inline content (this repo: the hero's trailing red dot, ~0.02 per tick). Pin the animated span's box for the tween's lifetime:
+
+```ts
+gsap.set(el, { display: 'inline-block', width: el.offsetWidth }); // settled text is already rendered
+gsap.to(el, { ..., overwrite: true, onComplete: () => gsap.set(el, { clearProps: 'display,width' }) });
+```
+
+`overwrite: true` stops a hover re-entry's stale onComplete from unlocking mid-scramble. Precedent: `src/components/echo-text` (PR #38, CLS 0.122 → 0.012).
+
+## Common Mistakes
+
+- Trusting CLSCulprits' named culprit — verify with sources before touching anything.
+- Believing `opacity: 0` exempts content from CLS — it does not; only `visibility: hidden` does.
+- Fixing the animation but leaving it running behind a dismissed overlay — cap BOTH paint (visibility) and the loop itself.
+- Verifying on `next dev` — measure a production build (`pnpm build` + `next start -p <port>`).

--- a/.claude/skills/diagnosing-missing-edge-compression/SKILL.md
+++ b/.claude/skills/diagnosing-missing-edge-compression/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: diagnosing-missing-edge-compression
+description: Use when a response served through Cloudflare (Workers/OpenNext) arrives uncompressed — no content-encoding header, transferred size equals raw size despite Accept-Encoding gzip/br/zstd — or when auditing transfer sizes shows full-size HTML/JS.
+---
+
+# Diagnosing Missing Edge Compression on Cloudflare
+
+## Overview
+
+**Cloudflare's edge refuses to transform (= compress) any response carrying a strong ETag.** A strong ETag (`"abc"`, no `W/` prefix) promises byte-identity; compressing would break that promise, so the edge skips compression entirely. This is the #1 cause of uncompressed responses behind Cloudflare and it applies to Worker-generated responses AND Workers Static Assets.
+
+Facts that counter the usual wrong guesses:
+
+- Cloudflare **does** auto-compress Worker-generated responses (gzip/br/zstd, per Accept-Encoding). No CompressionStream, no in-worker compression needed.
+- Workers Static Assets are **not** "uncompressed by design" — their default strong ETag is what blocks compression.
+- An explicit `Content-Encoding: identity` from the origin/worker also blocks it (OpenNext sets this only for `localhost` — a wrangler-dev workaround, irrelevant in production).
+- Zone toggles (Brotli setting) are almost never the cause.
+
+## Verify (before theorizing)
+
+```bash
+# Same size with and without Accept-Encoding == not compressed. Trust bytes, not headers.
+curl -s -o /dev/null -w '%{size_download}\n' https://site/
+curl -s -H 'Accept-Encoding: gzip, br' -o /dev/null -w '%{size_download}\n' https://site/
+```
+
+Then correlate: list several routes' `etag` / `content-encoding` headers. In this repo's incident, every route WITH a strong ETag was uncompressed and every route WITHOUT one was zstd'd — that correlation is the proof.
+
+## Fixes (this repo's shipped pattern, PR #37)
+
+| Path | Fix | Why this shape |
+|---|---|---|
+| Worker-rendered (HTML/ISR) | Rewrite ETag to weak `W/"..."` in `worker/middleware/weaken-etag.ts` (Hono, post-`next()` `c.header()`) | Weak ETag keeps If-None-Match 304s while permitting transforms |
+| `/_next/static/*` assets | `public/_headers`: `! ETag` + `Cache-Control: public, max-age=31536000, immutable` | Workers Assets serve BEFORE the worker runs — no middleware can reach them. Hashed URLs need no validator; removing ETag without adding `immutable` would regress to full re-downloads |
+| Unhashed public assets (og images) | Leave alone | Stable URLs need ETag 304s; images are incompressible anyway |
+
+## Common Mistakes
+
+- Adding in-worker CompressionStream — unnecessary; fix the ETag instead.
+- Removing an asset ETag without upgrading Cache-Control to `immutable` — kills 304 revalidation.
+- Judging a deploy "broken" from headers fetched < 1 min after deploy — Worker version propagation lags; re-check after a minute.
+- Reasoning from headers alone — always compare transferred byte counts.


### PR DESCRIPTION
## Summary

Two reference skills distilled from today's performance work (PR #37 / PR #38), written TDD-style: a baseline subagent probe first (documenting the exact wrong answers a skill-less agent gives), then the skill, then a with-skill verification run.

- **diagnosing-missing-edge-compression** — Cloudflare's edge won't compress responses carrying a strong ETag. Baseline agent confabulated "Worker responses bypass edge compression" and proposed in-worker CompressionStream; with the skill it diagnoses the ETag correctly and reproduces the worker (`W/` rewrite) vs Workers Assets (`_headers`: `! ETag` + `immutable`) fix split.
- **debugging-cumulative-layout-shift** — DevTools CLS attribution is heuristic; ground truth = `layout-shift` entry `sources`. Baseline agent asserted "opacity:0 produces zero layout shifts" (wrong — only `visibility: hidden` exempts); with the skill it correctly identifies the invisible-overlay afterlife pattern and the fix order.

Docs only — no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7Jcn74YdSrvxtkBt6GTAt