### PR TITLE
fix(contact): render /contact per request so Turnstile gets the real site key

### DIFF
--- a/.claude/rules/isr-revalidation.md
+++ b/.claude/rules/isr-revalidation.md
@@ -59,6 +59,33 @@ List pages paginate via `/blog/page/[num]` routes, NOT `?page=N`. Reading `searc
 
 `next build` prerenders CMS pages EMPTY (payload bindings are inert at build). `scripts/bust-isr-cache.mjs` — run at the tail of `deploy:staging` / `deploy:production` — is the ONLY mechanism that flushes that empty snapshot now that there is no hourly self-heal. Keep its tag list in sync with the wiring table above.
 
+## Never read runtime `env` from a prerendered page
+
+`getCloudflareContext().env` resolves on whatever machine renders the page. During
+`next build` that is the CI runner, where `.github/actions/setup` seeds `.dev.vars`
+from `.dev.vars.example`. A statically prerendered page therefore bakes those
+placeholder values into its HTML and keeps serving them for `s-maxage=31536000` —
+with no revalidate window and no `bust-isr-cache.mjs` entry, forever.
+
+This shipped: `/contact` served `turnstileSiteKey: "dev-placeholder"` in production,
+Turnstile answered `400` on the bogus key, its widget fell back to the error card
+(the stray "Troubleshoot" link), and the submit button stayed permanently disabled.
+
+Any page whose **render** reads `env` — or any other deploy/request-time value — must
+opt out of static prerendering:
+
+```ts
+// The page reads TURNSTILE_SITE_KEY from the Cloudflare env at render time.
+export const dynamic = 'force-dynamic';
+```
+
+A genuine dynamic API works too, and is why `/oauth/authorize` was never affected: it
+awaits `searchParams`, so Next never prerenders it. Route handlers and Server Actions
+always run per request and are safe.
+
+Verify with the build output — the route must print `ƒ (Dynamic)`, and must be absent
+from `.next/prerender-manifest.json`.
+
 ## Anti-patterns
 
 ```ts

--- a/src/app/(site)/contact/page.test.tsx
+++ b/src/app/(site)/contact/page.test.tsx
@@ -2,7 +2,7 @@ import { render } from 'vitest-browser-react';
 import { describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 
-import ContactPage from './page';
+import ContactPage, { dynamic } from './page';
 
 // Isolate the page-structure test from the form's server action / Cloudflare
 // context by stubbing the client form.
@@ -16,6 +16,16 @@ vi.mock('@opennextjs/cloudflare', () => ({
 }));
 
 describe('ContactPage', () => {
+  // Regression guard for the "dev-placeholder" incident: a statically prerendered
+  // /contact resolves the Cloudflare env on the BUILD machine, where CI seeds
+  // .dev.vars from .dev.vars.example (TURNSTILE_SITE_KEY=dev-placeholder). That
+  // string got frozen into the cached HTML — which carries no revalidate and is not
+  // in bust-isr-cache.mjs — so Turnstile 400'd forever and the submit button stayed
+  // disabled. Rendering per request is what keeps the real key reaching the widget.
+  it('opts out of static prerendering so the Turnstile site key comes from the runtime env', () => {
+    expect(dynamic).toBe('force-dynamic');
+  });
+
   it('does not render the page heading or main landmark (owned by the layout)', async () => {
     render(await ContactPage());
     expect(page.getByRole('heading', { level: 1 }).elements()).toHaveLength(0);

--- a/src/app/(site)/contact/page.tsx
+++ b/src/app/(site)/contact/page.tsx
@@ -19,6 +19,13 @@ const contactDescription = 'お問い合わせ — フォーム、または各�
 // was missing.
 export const generateMetadata = (): Metadata => resolveSectionMetadata({ docTitle: 'contact', description: contactDescription, path: '/contact' });
 
+// ContactFormLoader reads TURNSTILE_SITE_KEY from the Cloudflare env. A static
+// prerender resolves that env on the BUILD machine — where CI seeds .dev.vars from
+// .dev.vars.example — so `dev-placeholder` gets frozen into the cached HTML, and the
+// page has neither a time-based revalidate nor a bust-isr-cache entry to heal it.
+// The page holds no CMS data, so rendering per request costs little.
+export const dynamic = 'force-dynamic';
+
 const ContactPage = () => {
   return (
     <div className={s.grid}>


### PR DESCRIPTION
## 症状

https://napochaan.com/contact でフォームが送信できない。ウィジェット部分に「Troubleshoot」という謎の文字列が出る。

## 根本原因

`/contact` は**ビルド時プリレンダの静的ページ**だった (`x-nextjs-prerender: 1` / `s-maxage=31536000`)。`ContactFormLoader` は `getCloudflareContext().env.TURNSTILE_SITE_KEY` を**レンダー時**に読むため、その「レンダー時」がビルドマシン＝CI ランナーになる。CI では `.github/actions/setup` が `cp -n .dev.vars.example .dev.vars` するので、wrangler の `getPlatformProxy` が `dev-placeholder` を返し、それが HTML に焼き込まれた。

```
CI: cp .dev.vars.example .dev.vars   (cf:types のため)
      ↓
next build が /contact を静的プリレンダ → sitekey = "dev-placeholder"
      ↓
R2 incremental cache へ (1年キャッシュ・revalidate 無し・bust-isr-cache 対象外)
      ↓
Turnstile が sitekey 不正で 400 → ウィジェットがエラーカード表示（＝「Troubleshoot」リンク）
      ↓
onSuccess 未発火 → token === undefined → 送信ボタンが永久に disabled
```

本番の RSC ペイロード実測:

```
turnstileSiteKey\":\"dev-placeholder\"
```

ブラウザコンソール実測:

```
Failed to load resource: 400 @ challenges.cloudflare.com/.../turnstile/.../dev-placeholder/auto/...
```

`isr-revalidation.md` が既に書いている「ビルド時はバインディングが inert」問題の **env 版**。時間ベースの revalidate も purge 経路も無いため、自然回復しない。

## 修正

`/contact` を静的プリレンダから外す (`export const dynamic = 'force-dynamic'`)。CMS データを持たない軽いページなのでリクエスト毎レンダーのコストは小さく、env が焼き込まれる余地が原理的に無くなる。

## 検証

- `next build` の出力が `ƒ /contact`（Dynamic）になり、`.next/prerender-manifest.json` から消えた（`/about` は静的のまま）
- ローカル OpenNext preview (`pnpm preview`) で `/contact` を2回リクエスト → 毎回**実キー** `0x4AAAAAAD...` を返し、`x-nextjs-prerender` / `x-opennext-cache: HIT` は付かず `Cache-Control: private, no-cache, no-store`
- 同 preview をブラウザで開き、ウィジェット解決後に送信ボタンが enabled になることを確認
- 本番の実オリジン (`https://napochaan.com`) 上で本番 sitekey を直接 render → **トークン発行に成功**。許可ドメイン設定は無関係で、`docs/production-deploy.md` / memory にあった「napochaan.com を許可ドメインに追加」は既に済んでいた
- 本番 worker の secret 一覧に `TURNSTILE_SECRET_KEY` / `RESEND_API_KEY` / `DISCORD_WEBHOOK_URL` があることを確認（サーバ側は揃っている）
- `pnpm lint` / `pnpm typecheck` clean、contact テスト 12 pass

## 再発防止

- `page.test.tsx` に回帰ガード（`dynamic === 'force-dynamic'` を、理由コメント付きで固定）
- `.claude/rules/isr-revalidation.md` に「プリレンダされるページでランタイム `env` を読むな」節を追加。`/oauth/authorize` が無事だった理由（`await searchParams` で元々 dynamic）と、ビルド出力での確認方法も記載

## デプロイ

main マージで staging が自動デプロイ。本番は承認ゲート付き `workflow_dispatch` なので napochaan 自身が実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3NjfB298FoAqZrVUKva4U