### PR TITLE
feat(mcp): migrate the MCP server to v2 (@modelcontextprotocol/server 2.0.0)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
+++ b/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
@@ -1,0 +1,444 @@
+# MCP v2 移行 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 自前 MCP 実装を v1 モノリス `@modelcontextprotocol/sdk` から v2 の `@modelcontextprotocol/server` へ移行し、併せて zod を 4 系に上げる。
+
+**Architecture:** 3 段階に分離する。(1) `@hono/zod-validator` を zod 3/4 両対応版に上げる → (2) zod 本体を 4 に上げる → (3) MCP SDK を差し替える。同時にやると破壊の切り分けが不能になるため、各段階を独立に検証する。MCP 側は `WebStandardStreamableHTTPServerTransport` が v2 でも同一 API で提供されるため、`src/app/api/mcp/route.ts` の骨格は変更しない。
+
+**Tech Stack:** Next.js 15 (App Router) / Cloudflare Workers (workerd) / OpenNext / Hono / zod / `@modelcontextprotocol/server` 2.0.0 / vitest (`@cloudflare/vitest-pool-workers` 含む)
+
+## Global Constraints
+
+- `zod` は `^4.2.0` 以上（v2 SDK の要求。zod@3 では**ツールが最初に list されたときに初めて壊れる**＝サイレント破壊）
+- `@hono/zod-validator` は `^0.9.0`（peer: `zod ^3.25.0 || ^4.0.0`）。zod 昇格より**先に**上げる
+- `@modelcontextprotocol/server` は `^2.0.0`（peer/deps に `@modelcontextprotocol/core@2.0.0` と `zod ^4.2.0`）
+- `@modelcontextprotocol/sdk`（v1 モノリス）は**削除する**。2.x は存在しない
+- `hono` は `^4.12.23`（既存）で v2 アダプタの peer `^4.11.4` を満たす。変更不要
+- 各タスク完了時に `pnpm lint && pnpm typecheck` を通すこと（`.claude/rules/coding-rules.md`）
+- **勝手に commit しない**（`CLAUDE.md`）。commit は最終レビュー承認後にまとめて行う
+- 関数は arrow function、`let`/IIFE/非 null assertion/`forEach`/`any` 禁止（`.claude/rules/functional-programming.md`, `function-style.md`）
+
+## 事前に実測済みの事実（推測ではない）
+
+計画の前提はすべて 2026-08-18 に実物で確認済み。詳細は `reports/2026-08-18-mcp-v2-migration-assessment.md`。
+
+| 確認事項 | 結果 |
+| --- | --- |
+| `WebStandardStreamableHTTPServerTransport` の v2 での提供 | `@modelcontextprotocol/server` から export。オプション同一 |
+| `transport.handleRequest(request)` の第2引数 | `handleRequest(req: Request, options?: HandleRequestOptions)` = **省略可** |
+| `registerTool` の生シェイプ `inputSchema` | `InputArgs extends ZodRawShape` overload が存在（`auto-wrapped with z.object()`）= **12 箇所とも書き換え不要** |
+| zod 4 の `z` named / default export | 両方あり |
+| zod 4 の `.email({ message })` / `.min(1, { message })` | 動作する |
+| zod 4 の `error.flatten().fieldErrors` | 動作し、出力も v3 と同一 |
+| zod 4 の `z.discriminatedUnion` | 動作する |
+| workerd での JSON Schema validator | `jsonSchemaValidator` の既定が**ランタイム自動判別**（Node=AJV / workerd=`@cfworker/json-schema`）。手動注入は原則不要 |
+
+→ 想定される**ソース変更はごく小さい**。大半は依存の差し替えと検証。
+
+## File Structure
+
+| ファイル | 役割 | 本計画での扱い |
+| --- | --- | --- |
+| `package.json` | 依存定義 | Task 1/2/3 で変更 |
+| `src/app/api/mcp/route.ts` | MCP サーバのエントリ（transport 生成・tool 登録） | Task 3 で import 2 行のみ変更 |
+| `src/app/api/mcp/route.test.ts` | 上記のユニットテスト（SDK を `vi.mock` している） | Task 3 で mock パス 2 箇所を変更 |
+| `src/lib/mcp/tools/index.ts` | blog 系 tool 登録（`McpServer` を型としてのみ import） | Task 3 で type import 1 行を変更 |
+| `src/lib/mcp/tools/legal/index.ts` | legal 系 tool 登録（同上） | Task 3 で type import 1 行を変更 |
+| `worker/mcp-v2-runtime.test.ts` | **新規**。workerd 実行環境で v2 SDK が動くことを固定する回帰テスト | Task 4 で新規作成 |
+
+zod を import する 6 ファイル（`src/lib/mcp/tools/index.ts`, `src/lib/mcp/tools/legal/index.ts`, `src/app/api/media-upload/route.ts`, `src/lib/contact/schema.ts`, `src/lib/cursor/protocol.ts`, `worker/handlers/images/index.ts`）と `src/app/(site)/contact/_actions/submit-contact.ts`（`error.flatten()` 使用）は、実測上ソース変更不要の見込み。Task 2 のテストで実際に確認する。
+
+---
+
+### Task 1: `@hono/zod-validator` を zod 3/4 両対応版へ上げる
+
+zod 本体はまだ動かさない。このタスク単体では**挙動が変わらない**ことを確認するのが目的。
+
+**Files:**
+- Modify: `package.json`（`"@hono/zod-validator": "^0.7.6"` → `"^0.9.0"`）
+- Test: `src/app/api/media-upload/route.test.ts`, `worker/handlers/images/helpers.test.ts`
+
+**Interfaces:**
+- Consumes: なし（最初のタスク）
+- Produces: `@hono/zod-validator@^0.9.0` がインストールされた状態。peer が `zod ^3.25.0 || ^4.0.0` になり、Task 2 の zod 4 昇格が peer 衝突なしに行える
+
+- [ ] **Step 1: 変更前のベースラインを取る**
+
+Run:
+```bash
+pnpm exec vitest run src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
+```
+Expected: PASS（現状の緑を記録する。ここが赤なら本計画とは無関係の既存不具合なので、先に報告して停止すること）
+
+- [ ] **Step 2: バージョンを上げる**
+
+Run:
+```bash
+pnpm add @hono/zod-validator@^0.9.0
+```
+
+- [ ] **Step 3: peer が zod 4 を受け入れることを確認**
+
+Run:
+```bash
+pnpm why zod | head -20
+node -e "console.log(require('./node_modules/@hono/zod-validator/package.json').peerDependencies)"
+```
+Expected: `{ hono: '>=4.11.2', zod: '^3.25.0 || ^4.0.0' }` が出力される
+
+- [ ] **Step 4: 挙動不変を確認**
+
+Run:
+```bash
+pnpm exec vitest run src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
+pnpm lint && pnpm typecheck
+```
+Expected: すべて PASS（Step 1 と同じ結果）
+
+---
+
+### Task 2: zod を 4 系へ上げる
+
+MCP には一切触らない。zod 単独の破壊があればここで顕在化させる。
+
+**Files:**
+- Modify: `package.json`（`"zod": "^3.25.76"` → `"^4.2.0"`）
+- Test: `src/lib/contact/schema.test.ts`, `src/lib/cursor/protocol.test.ts`, `src/app/api/media-upload/route.test.ts`, `worker/handlers/images/helpers.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 の `@hono/zod-validator@^0.9.0`
+- Produces: `zod@^4.2.0`。v2 SDK が要求する zod 4 環境が整う
+
+- [ ] **Step 1: バージョンを上げる**
+
+Run:
+```bash
+pnpm add zod@^4.2.0
+```
+
+- [ ] **Step 2: 型を通す**
+
+Run:
+```bash
+pnpm typecheck
+```
+Expected: エラーなし。
+
+もしエラーが出た場合の既知の対処（実測で不要と判明しているが、環境差で出た場合のみ適用）:
+- `z.string().email({ message })` が型エラー → `z.email({ message })` に置換（`src/lib/contact/schema.ts:5`）
+- `error.flatten()` が型エラー → `z.flattenError(error)` に置換（`src/app/(site)/contact/_actions/submit-contact.ts:45`）
+
+いずれも**動作は実測で確認済み**なので、型エラーが出ない限り書き換えないこと（YAGNI）。
+
+- [ ] **Step 3: zod を使う全テストを走らせる**
+
+Run:
+```bash
+pnpm exec vitest run src/lib/contact/schema.test.ts src/lib/cursor/protocol.test.ts src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 4: 全テストを走らせる**
+
+Run:
+```bash
+pnpm test
+```
+Expected: PASS。MCP 系テスト（`src/lib/mcp/**`）もこの時点ではまだ v1 SDK のまま緑であること
+
+- [ ] **Step 5: lint / typecheck**
+
+Run:
+```bash
+pnpm lint && pnpm typecheck
+```
+Expected: PASS
+
+---
+
+### Task 3: MCP SDK を v2 パッケージへ差し替える
+
+**Files:**
+- Modify: `package.json`（`@modelcontextprotocol/sdk` を削除し `@modelcontextprotocol/server@^2.0.0` を追加）
+- Modify: `src/app/api/mcp/route.ts:4-5`
+- Modify: `src/app/api/mcp/route.test.ts:19,25`
+- Modify: `src/lib/mcp/tools/index.ts:35`
+- Modify: `src/lib/mcp/tools/legal/index.ts:17`
+- Test: `src/app/api/mcp/route.test.ts`, `src/lib/mcp/tools/tools.test.ts`, `src/lib/mcp/tools/legal/legal.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2 の `zod@^4.2.0`
+- Produces: `McpServer` と `WebStandardStreamableHTTPServerTransport` が `@modelcontextprotocol/server`（サブパスなしのメイン export）から供給される状態。`registerTool` / `server.connect` / `transport.handleRequest` の呼び出し形は変更しない
+
+- [ ] **Step 1: テストの mock パスを先に v2 へ書き換える（失敗させる）**
+
+`src/app/api/mcp/route.test.ts` の 19 行目と 25 行目、2 つの `vi.mock` の対象パスを 1 つに統合する。
+
+変更前（19-31 行目、2 ブロック）:
+```ts
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: class {
+    registerTool(): void {}
+    async connect(): Promise<void> {}
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js', () => ({
+  WebStandardStreamableHTTPServerTransport: class {
+    async handleRequest(): Promise<Response> {
+      return new Response('{}', { status: 200 });
+    }
+  },
+}));
+```
+
+変更後（v2 は両方ともメイン export なので 1 ブロックに統合する）:
+```ts
+vi.mock('@modelcontextprotocol/server', () => ({
+  McpServer: class {
+    registerTool(): void {}
+    async connect(): Promise<void> {}
+  },
+  WebStandardStreamableHTTPServerTransport: class {
+    async handleRequest(): Promise<Response> {
+      return new Response('{}', { status: 200 });
+    }
+  },
+}));
+```
+
+- [ ] **Step 2: テストを走らせて失敗することを確認**
+
+Run:
+```bash
+pnpm exec vitest run src/app/api/mcp/route.test.ts
+```
+Expected: FAIL（`@modelcontextprotocol/server` が未インストールのため解決できない旨のエラー）
+
+- [ ] **Step 3: パッケージを差し替える**
+
+Run:
+```bash
+pnpm remove @modelcontextprotocol/sdk
+pnpm add @modelcontextprotocol/server@^2.0.0
+```
+
+- [ ] **Step 4: 実装側の import を書き換える**
+
+`src/app/api/mcp/route.ts:4-5` — 2 行を 1 行にまとめる。
+
+変更前:
+```ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+```
+
+変更後:
+```ts
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+```
+
+`src/lib/mcp/tools/index.ts:35` と `src/lib/mcp/tools/legal/index.ts:17` — 型 import を書き換える。
+
+変更前:
+```ts
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+```
+
+変更後:
+```ts
+import type { McpServer } from '@modelcontextprotocol/server';
+```
+
+`new McpServer({ name: 'napochaan-blog', version: '1.0.0' })`、`server.connect(transport)`、`transport.handleRequest(request)`、`new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })`、および 12 箇所の `server.registerTool(...)` は**いずれも変更しない**（v2 で同一 API であることを実測済み）。
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run:
+```bash
+pnpm exec vitest run src/app/api/mcp/route.test.ts src/lib/mcp/tools/tools.test.ts src/lib/mcp/tools/legal/legal.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 6: 残存参照がないことを確認**
+
+Run:
+```bash
+grep -rn "@modelcontextprotocol/sdk" src worker package.json
+```
+Expected: 出力なし（1 件でも残っていたら書き換え漏れ）
+
+- [ ] **Step 7: 全テスト + lint + typecheck**
+
+Run:
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+```
+Expected: PASS
+
+---
+
+### Task 4: workerd 実行環境で v2 SDK が動くことを固定する
+
+`route.test.ts` は SDK を `vi.mock` しているため、**実物の SDK が workerd で動く保証にならない**。v1 で Payload plugin がハングした場所がまさにここなので、workerd 実行環境の回帰テストを新設する。
+
+`worker/**/*.test.ts` は vitest の worker project（`@cloudflare/vitest-pool-workers`, `wrangler.toml` の `environment: 'test'`）で走るため、**実際の workerd 上で実行される**。
+
+未検証項目だった「`validators/cf-worker` への差し替えが必要か」も、このテストで判明する。
+
+**Files:**
+- Create: `worker/mcp-v2-runtime.test.ts`
+- Test: 同上
+
+**Interfaces:**
+- Consumes: Task 3 の `@modelcontextprotocol/server@^2.0.0`
+- Produces: workerd 上で `McpServer` + `WebStandardStreamableHTTPServerTransport` が `tools/list` を返せることを保証する回帰テスト
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+Create `worker/mcp-v2-runtime.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+
+// v1 では mcp-handler が Node 版 transport を掴んでいたため workerd 上でリクエストが
+// ハングした(reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md)。
+// route.test.ts は SDK を vi.mock しているのでこの層を守れない。ここだけが
+// 「実物の SDK が workerd で動く」ことを保証している。消さないこと。
+const buildRequest = (body: unknown): Request =>
+  new Request('https://example.test/api/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify(body),
+  });
+
+const handle = async (body: unknown): Promise<Response> => {
+  const server = new McpServer({ name: 'runtime-probe', version: '1.0.0' });
+  server.registerTool(
+    'echo',
+    { title: 'echo', description: 'workerd 実行確認用', inputSchema: { value: z.string() } },
+    ({ value }) => ({ content: [{ type: 'text' as const, text: value }] }),
+  );
+  const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true });
+  await server.connect(transport);
+  return transport.handleRequest(buildRequest(body));
+};
+
+describe('MCP v2 SDK on workerd', () => {
+  it('responds to tools/list without hanging', async () => {
+    const response = await handle({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { result?: { tools?: { name: string }[] } };
+    expect(payload.result?.tools?.map((tool) => tool.name)).toContain('echo');
+  });
+
+  it('executes a tool call', async () => {
+    const response = await handle({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'echo', arguments: { value: 'ok' } } });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { result?: { content?: { text?: string }[] } };
+    expect(payload.result?.content?.[0]?.text).toBe('ok');
+  });
+});
+```
+
+- [ ] **Step 2: 走らせて結果を確認**
+
+Run:
+```bash
+pnpm exec vitest run worker/mcp-v2-runtime.test.ts
+```
+
+分岐:
+- **PASS** → `validators/cf-worker` への差し替えは不要。Step 3 を飛ばして Step 4 へ
+- **FAIL**（`new Function` / `eval` / CSP 由来のエラー、あるいはハング）→ Step 3 を実施
+
+- [ ] **Step 3: (Step 2 が FAIL の場合のみ) Workers 向け validator に差し替える**
+
+SDK の型定義によれば `jsonSchemaValidator` の既定値は
+*"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on browser/workerd runtimes)"*
+＝ **workerd は SDK 側が自動判別する**ため、通常この Step は不要（Step 2 は PASS するはず）。
+自動判別が効かなかった場合のみ、`McpServer` の第 2 引数（`ServerOptions`）で明示注入する。
+
+```ts
+import { McpServer } from '@modelcontextprotocol/server';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
+
+const server = new McpServer(
+  { name: 'napochaan-blog', version: '1.0.0' },
+  { jsonSchemaValidator: new CfWorkerJsonSchemaValidator() },
+);
+```
+
+差し替えが必要だった場合は、**`src/app/api/mcp/route.ts` 側にも同じ注入を入れる**こと（テストだけ通っても本番が落ちる）。
+
+- [ ] **Step 4: 全テスト + lint + typecheck**
+
+Run:
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+```
+Expected: PASS
+
+---
+
+### Task 5: ガード境界の疎通確認とレビュー依頼
+
+v2 はステートレス化に伴い `Mcp-Method` / `Mcp-Name` ヘッダが増える。うちのセキュリティ境界（`worker/routes/mcp-guard.ts` の外部遮断、`worker/worker.ts` の `apiRoute: '/mcp'` 判定）がこれに影響を受けないことを確認する。
+
+**Files:**
+- Test: `worker/app.test.ts`, `worker/routes/mcp-guard.test.ts`
+- Modify: なし（想定。影響が出た場合のみ該当ファイル）
+
+**Interfaces:**
+- Consumes: Task 4 までの全変更
+- Produces: レビュー可能な差分
+
+- [ ] **Step 1: ガード境界のテストを走らせる**
+
+Run:
+```bash
+pnpm exec vitest run worker/app.test.ts worker/routes/mcp-guard.test.ts
+```
+Expected: PASS。`/api/mcp` が外部から 404 で遮断され続けていること（ガードの登録順序がセキュリティ境界そのものであるため、ここが赤なら移行を止めて報告すること）
+
+- [ ] **Step 2: 本番相当ビルドが通ることを確認**
+
+Run:
+```bash
+pnpm build
+```
+Expected: 成功。v2 SDK が OpenNext のバンドルに乗ることを確認する（`worker/**` の vitest は workerd だが、Next 側のバンドル経路は別）
+
+- [ ] **Step 3: 最終の全体検証**
+
+Run:
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+```
+Expected: すべて PASS
+
+- [ ] **Step 4: difit でレビュー依頼**
+
+Run:
+```bash
+pnpm difit
+```
+
+差分を提示してレビューを依頼する。**この時点では commit しない**（`CLAUDE.md`「勝手に commit しないこと」）。
+
+- [ ] **Step 5: (レビュー承認後) commit**
+
+承認を得てから実施する。段階が切り分けられるよう、Task 1-2（依存昇格）と Task 3-4（MCP v2 移行）で commit を分けること。
+
+---
+
+## 本計画の範囲外
+
+- **staging への deploy と実 OAuth 経路の E2E**: 外部に出る操作なので本計画には含めない。ローカル workerd での確認（Task 4）まで完了させ、deploy の可否は別途判断する。
+- **DCR → CIMD 移行**: v2 で Dynamic Client Registration が deprecated（サポート期間 12 ヶ月）。`worker/worker.ts` の `clientRegistrationEndpoint: '/oauth/register'` は当面動作するため、本計画では扱わない。期限付きの watch item として `reports/2026-08-18-mcp-v2-migration-assessment.md` に記録済み。
+- **`@modelcontextprotocol/hono` の導入**: 現行は Next の route handler で完結しており、Hono アダプタを挟む必要がない。将来 MCP を worker の Hono 層へ移す場合の選択肢として記録するに留める。

--- a/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
+++ b/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
@@ -16,7 +16,10 @@
 - `@modelcontextprotocol/sdk`（v1 モノリス）は**削除する**。2.x は存在しない
 - `hono` は `^4.12.23`（既存）で v2 アダプタの peer `^4.11.4` を満たす。変更不要
 - 各タスク完了時に `pnpm lint && pnpm typecheck` を通すこと（`.claude/rules/coding-rules.md`）
-- **勝手に commit しない**（`CLAUDE.md`）。commit は最終レビュー承認後にまとめて行う
+- commit 運用: **タスク毎に commit してよい**（本人承認 2026-08-18。この決定が下の `CLAUDE.md` 既定を上書きする）。
+  ただし **push と PR 作成はしない** — それらは difit レビュー承認後に別途判断する。
+  （既定は `CLAUDE.md` の「勝手に commit しないこと」。本ブランチはローカル専用の feature branch であり、
+  タスク単位で差分が分離されている方がレビュー精度と巻き戻しやすさで勝るため、本人が明示的に緩和した）
 - 関数は arrow function、`let`/IIFE/非 null assertion/`forEach`/`any` 禁止（`.claude/rules/functional-programming.md`, `function-style.md`）
 
 ## 事前に実測済みの事実（推測ではない）

--- a/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
+++ b/docs/superpowers/plans/2026-08-18-mcp-v2-migration.md
@@ -23,29 +23,29 @@
 
 計画の前提はすべて 2026-08-18 に実物で確認済み。詳細は `reports/2026-08-18-mcp-v2-migration-assessment.md`。
 
-| 確認事項 | 結果 |
-| --- | --- |
-| `WebStandardStreamableHTTPServerTransport` の v2 での提供 | `@modelcontextprotocol/server` から export。オプション同一 |
-| `transport.handleRequest(request)` の第2引数 | `handleRequest(req: Request, options?: HandleRequestOptions)` = **省略可** |
-| `registerTool` の生シェイプ `inputSchema` | `InputArgs extends ZodRawShape` overload が存在（`auto-wrapped with z.object()`）= **12 箇所とも書き換え不要** |
-| zod 4 の `z` named / default export | 両方あり |
-| zod 4 の `.email({ message })` / `.min(1, { message })` | 動作する |
-| zod 4 の `error.flatten().fieldErrors` | 動作し、出力も v3 と同一 |
-| zod 4 の `z.discriminatedUnion` | 動作する |
-| workerd での JSON Schema validator | `jsonSchemaValidator` の既定が**ランタイム自動判別**（Node=AJV / workerd=`@cfworker/json-schema`）。手動注入は原則不要 |
+| 確認事項                                                  | 結果                                                                                                                   |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `WebStandardStreamableHTTPServerTransport` の v2 での提供 | `@modelcontextprotocol/server` から export。オプション同一                                                             |
+| `transport.handleRequest(request)` の第2引数              | `handleRequest(req: Request, options?: HandleRequestOptions)` = **省略可**                                             |
+| `registerTool` の生シェイプ `inputSchema`                 | `InputArgs extends ZodRawShape` overload が存在（`auto-wrapped with z.object()`）= **12 箇所とも書き換え不要**         |
+| zod 4 の `z` named / default export                       | 両方あり                                                                                                               |
+| zod 4 の `.email({ message })` / `.min(1, { message })`   | 動作する                                                                                                               |
+| zod 4 の `error.flatten().fieldErrors`                    | 動作し、出力も v3 と同一                                                                                               |
+| zod 4 の `z.discriminatedUnion`                           | 動作する                                                                                                               |
+| workerd での JSON Schema validator                        | `jsonSchemaValidator` の既定が**ランタイム自動判別**（Node=AJV / workerd=`@cfworker/json-schema`）。手動注入は原則不要 |
 
 → 想定される**ソース変更はごく小さい**。大半は依存の差し替えと検証。
 
 ## File Structure
 
-| ファイル | 役割 | 本計画での扱い |
-| --- | --- | --- |
-| `package.json` | 依存定義 | Task 1/2/3 で変更 |
-| `src/app/api/mcp/route.ts` | MCP サーバのエントリ（transport 生成・tool 登録） | Task 3 で import 2 行のみ変更 |
-| `src/app/api/mcp/route.test.ts` | 上記のユニットテスト（SDK を `vi.mock` している） | Task 3 で mock パス 2 箇所を変更 |
-| `src/lib/mcp/tools/index.ts` | blog 系 tool 登録（`McpServer` を型としてのみ import） | Task 3 で type import 1 行を変更 |
-| `src/lib/mcp/tools/legal/index.ts` | legal 系 tool 登録（同上） | Task 3 で type import 1 行を変更 |
-| `worker/mcp-v2-runtime.test.ts` | **新規**。workerd 実行環境で v2 SDK が動くことを固定する回帰テスト | Task 4 で新規作成 |
+| ファイル                           | 役割                                                               | 本計画での扱い                   |
+| ---------------------------------- | ------------------------------------------------------------------ | -------------------------------- |
+| `package.json`                     | 依存定義                                                           | Task 1/2/3 で変更                |
+| `src/app/api/mcp/route.ts`         | MCP サーバのエントリ（transport 生成・tool 登録）                  | Task 3 で import 2 行のみ変更    |
+| `src/app/api/mcp/route.test.ts`    | 上記のユニットテスト（SDK を `vi.mock` している）                  | Task 3 で mock パス 2 箇所を変更 |
+| `src/lib/mcp/tools/index.ts`       | blog 系 tool 登録（`McpServer` を型としてのみ import）             | Task 3 で type import 1 行を変更 |
+| `src/lib/mcp/tools/legal/index.ts` | legal 系 tool 登録（同上）                                         | Task 3 で type import 1 行を変更 |
+| `worker/mcp-v2-runtime.test.ts`    | **新規**。workerd 実行環境で v2 SDK が動くことを固定する回帰テスト | Task 4 で新規作成                |
 
 zod を import する 6 ファイル（`src/lib/mcp/tools/index.ts`, `src/lib/mcp/tools/legal/index.ts`, `src/app/api/media-upload/route.ts`, `src/lib/contact/schema.ts`, `src/lib/cursor/protocol.ts`, `worker/handlers/images/index.ts`）と `src/app/(site)/contact/_actions/submit-contact.ts`（`error.flatten()` 使用）は、実測上ソース変更不要の見込み。Task 2 のテストで実際に確認する。
 
@@ -56,24 +56,29 @@ zod を import する 6 ファイル（`src/lib/mcp/tools/index.ts`, `src/lib/mc
 zod 本体はまだ動かさない。このタスク単体では**挙動が変わらない**ことを確認するのが目的。
 
 **Files:**
+
 - Modify: `package.json`（`"@hono/zod-validator": "^0.7.6"` → `"^0.9.0"`）
 - Test: `src/app/api/media-upload/route.test.ts`, `worker/handlers/images/helpers.test.ts`
 
 **Interfaces:**
+
 - Consumes: なし（最初のタスク）
 - Produces: `@hono/zod-validator@^0.9.0` がインストールされた状態。peer が `zod ^3.25.0 || ^4.0.0` になり、Task 2 の zod 4 昇格が peer 衝突なしに行える
 
 - [ ] **Step 1: 変更前のベースラインを取る**
 
 Run:
+
 ```bash
 pnpm exec vitest run src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
 ```
+
 Expected: PASS（現状の緑を記録する。ここが赤なら本計画とは無関係の既存不具合なので、先に報告して停止すること）
 
 - [ ] **Step 2: バージョンを上げる**
 
 Run:
+
 ```bash
 pnpm add @hono/zod-validator@^0.9.0
 ```
@@ -81,19 +86,23 @@ pnpm add @hono/zod-validator@^0.9.0
 - [ ] **Step 3: peer が zod 4 を受け入れることを確認**
 
 Run:
+
 ```bash
 pnpm why zod | head -20
 node -e "console.log(require('./node_modules/@hono/zod-validator/package.json').peerDependencies)"
 ```
+
 Expected: `{ hono: '>=4.11.2', zod: '^3.25.0 || ^4.0.0' }` が出力される
 
 - [ ] **Step 4: 挙動不変を確認**
 
 Run:
+
 ```bash
 pnpm exec vitest run src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
 pnpm lint && pnpm typecheck
 ```
+
 Expected: すべて PASS（Step 1 と同じ結果）
 
 ---
@@ -103,16 +112,19 @@ Expected: すべて PASS（Step 1 と同じ結果）
 MCP には一切触らない。zod 単独の破壊があればここで顕在化させる。
 
 **Files:**
+
 - Modify: `package.json`（`"zod": "^3.25.76"` → `"^4.2.0"`）
 - Test: `src/lib/contact/schema.test.ts`, `src/lib/cursor/protocol.test.ts`, `src/app/api/media-upload/route.test.ts`, `worker/handlers/images/helpers.test.ts`
 
 **Interfaces:**
+
 - Consumes: Task 1 の `@hono/zod-validator@^0.9.0`
 - Produces: `zod@^4.2.0`。v2 SDK が要求する zod 4 環境が整う
 
 - [ ] **Step 1: バージョンを上げる**
 
 Run:
+
 ```bash
 pnpm add zod@^4.2.0
 ```
@@ -120,12 +132,15 @@ pnpm add zod@^4.2.0
 - [ ] **Step 2: 型を通す**
 
 Run:
+
 ```bash
 pnpm typecheck
 ```
+
 Expected: エラーなし。
 
 もしエラーが出た場合の既知の対処（実測で不要と判明しているが、環境差で出た場合のみ適用）:
+
 - `z.string().email({ message })` が型エラー → `z.email({ message })` に置換（`src/lib/contact/schema.ts:5`）
 - `error.flatten()` が型エラー → `z.flattenError(error)` に置換（`src/app/(site)/contact/_actions/submit-contact.ts:45`）
 
@@ -134,25 +149,31 @@ Expected: エラーなし。
 - [ ] **Step 3: zod を使う全テストを走らせる**
 
 Run:
+
 ```bash
 pnpm exec vitest run src/lib/contact/schema.test.ts src/lib/cursor/protocol.test.ts src/app/api/media-upload/route.test.ts worker/handlers/images/helpers.test.ts
 ```
+
 Expected: PASS
 
 - [ ] **Step 4: 全テストを走らせる**
 
 Run:
+
 ```bash
 pnpm test
 ```
+
 Expected: PASS。MCP 系テスト（`src/lib/mcp/**`）もこの時点ではまだ v1 SDK のまま緑であること
 
 - [ ] **Step 5: lint / typecheck**
 
 Run:
+
 ```bash
 pnpm lint && pnpm typecheck
 ```
+
 Expected: PASS
 
 ---
@@ -160,6 +181,7 @@ Expected: PASS
 ### Task 3: MCP SDK を v2 パッケージへ差し替える
 
 **Files:**
+
 - Modify: `package.json`（`@modelcontextprotocol/sdk` を削除し `@modelcontextprotocol/server@^2.0.0` を追加）
 - Modify: `src/app/api/mcp/route.ts:4-5`
 - Modify: `src/app/api/mcp/route.test.ts:19,25`
@@ -168,6 +190,7 @@ Expected: PASS
 - Test: `src/app/api/mcp/route.test.ts`, `src/lib/mcp/tools/tools.test.ts`, `src/lib/mcp/tools/legal/legal.test.ts`
 
 **Interfaces:**
+
 - Consumes: Task 2 の `zod@^4.2.0`
 - Produces: `McpServer` と `WebStandardStreamableHTTPServerTransport` が `@modelcontextprotocol/server`（サブパスなしのメイン export）から供給される状態。`registerTool` / `server.connect` / `transport.handleRequest` の呼び出し形は変更しない
 
@@ -176,6 +199,7 @@ Expected: PASS
 `src/app/api/mcp/route.test.ts` の 19 行目と 25 行目、2 つの `vi.mock` の対象パスを 1 つに統合する。
 
 変更前（19-31 行目、2 ブロック）:
+
 ```ts
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: class {
@@ -193,6 +217,7 @@ vi.mock('@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js', () => (
 ```
 
 変更後（v2 は両方ともメイン export なので 1 ブロックに統合する）:
+
 ```ts
 vi.mock('@modelcontextprotocol/server', () => ({
   McpServer: class {
@@ -210,14 +235,17 @@ vi.mock('@modelcontextprotocol/server', () => ({
 - [ ] **Step 2: テストを走らせて失敗することを確認**
 
 Run:
+
 ```bash
 pnpm exec vitest run src/app/api/mcp/route.test.ts
 ```
+
 Expected: FAIL（`@modelcontextprotocol/server` が未インストールのため解決できない旨のエラー）
 
 - [ ] **Step 3: パッケージを差し替える**
 
 Run:
+
 ```bash
 pnpm remove @modelcontextprotocol/sdk
 pnpm add @modelcontextprotocol/server@^2.0.0
@@ -228,12 +256,14 @@ pnpm add @modelcontextprotocol/server@^2.0.0
 `src/app/api/mcp/route.ts:4-5` — 2 行を 1 行にまとめる。
 
 変更前:
+
 ```ts
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 ```
 
 変更後:
+
 ```ts
 import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 ```
@@ -241,11 +271,13 @@ import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelconte
 `src/lib/mcp/tools/index.ts:35` と `src/lib/mcp/tools/legal/index.ts:17` — 型 import を書き換える。
 
 変更前:
+
 ```ts
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 ```
 
 変更後:
+
 ```ts
 import type { McpServer } from '@modelcontextprotocol/server';
 ```
@@ -255,25 +287,31 @@ import type { McpServer } from '@modelcontextprotocol/server';
 - [ ] **Step 5: テストが通ることを確認**
 
 Run:
+
 ```bash
 pnpm exec vitest run src/app/api/mcp/route.test.ts src/lib/mcp/tools/tools.test.ts src/lib/mcp/tools/legal/legal.test.ts
 ```
+
 Expected: PASS
 
 - [ ] **Step 6: 残存参照がないことを確認**
 
 Run:
+
 ```bash
 grep -rn "@modelcontextprotocol/sdk" src worker package.json
 ```
+
 Expected: 出力なし（1 件でも残っていたら書き換え漏れ）
 
 - [ ] **Step 7: 全テスト + lint + typecheck**
 
 Run:
+
 ```bash
 pnpm test && pnpm lint && pnpm typecheck
 ```
+
 Expected: PASS
 
 ---
@@ -287,10 +325,12 @@ Expected: PASS
 未検証項目だった「`validators/cf-worker` への差し替えが必要か」も、このテストで判明する。
 
 **Files:**
+
 - Create: `worker/mcp-v2-runtime.test.ts`
 - Test: 同上
 
 **Interfaces:**
+
 - Consumes: Task 3 の `@modelcontextprotocol/server@^2.0.0`
 - Produces: workerd 上で `McpServer` + `WebStandardStreamableHTTPServerTransport` が `tools/list` を返せることを保証する回帰テスト
 
@@ -349,18 +389,20 @@ describe('MCP v2 SDK on workerd', () => {
 - [ ] **Step 2: 走らせて結果を確認**
 
 Run:
+
 ```bash
 pnpm exec vitest run worker/mcp-v2-runtime.test.ts
 ```
 
 分岐:
+
 - **PASS** → `validators/cf-worker` への差し替えは不要。Step 3 を飛ばして Step 4 へ
 - **FAIL**（`new Function` / `eval` / CSP 由来のエラー、あるいはハング）→ Step 3 を実施
 
 - [ ] **Step 3: (Step 2 が FAIL の場合のみ) Workers 向け validator に差し替える**
 
 SDK の型定義によれば `jsonSchemaValidator` の既定値は
-*"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on browser/workerd runtimes)"*
+_"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on browser/workerd runtimes)"_
 ＝ **workerd は SDK 側が自動判別する**ため、通常この Step は不要（Step 2 は PASS するはず）。
 自動判別が効かなかった場合のみ、`McpServer` の第 2 引数（`ServerOptions`）で明示注入する。
 
@@ -379,9 +421,11 @@ const server = new McpServer(
 - [ ] **Step 4: 全テスト + lint + typecheck**
 
 Run:
+
 ```bash
 pnpm test && pnpm lint && pnpm typecheck
 ```
+
 Expected: PASS
 
 ---
@@ -391,40 +435,49 @@ Expected: PASS
 v2 はステートレス化に伴い `Mcp-Method` / `Mcp-Name` ヘッダが増える。うちのセキュリティ境界（`worker/routes/mcp-guard.ts` の外部遮断、`worker/worker.ts` の `apiRoute: '/mcp'` 判定）がこれに影響を受けないことを確認する。
 
 **Files:**
+
 - Test: `worker/app.test.ts`, `worker/routes/mcp-guard.test.ts`
 - Modify: なし（想定。影響が出た場合のみ該当ファイル）
 
 **Interfaces:**
+
 - Consumes: Task 4 までの全変更
 - Produces: レビュー可能な差分
 
 - [ ] **Step 1: ガード境界のテストを走らせる**
 
 Run:
+
 ```bash
 pnpm exec vitest run worker/app.test.ts worker/routes/mcp-guard.test.ts
 ```
+
 Expected: PASS。`/api/mcp` が外部から 404 で遮断され続けていること（ガードの登録順序がセキュリティ境界そのものであるため、ここが赤なら移行を止めて報告すること）
 
 - [ ] **Step 2: 本番相当ビルドが通ることを確認**
 
 Run:
+
 ```bash
 pnpm build
 ```
+
 Expected: 成功。v2 SDK が OpenNext のバンドルに乗ることを確認する（`worker/**` の vitest は workerd だが、Next 側のバンドル経路は別）
 
 - [ ] **Step 3: 最終の全体検証**
 
 Run:
+
 ```bash
 pnpm test && pnpm lint && pnpm typecheck
 ```
+
 Expected: すべて PASS
 
 - [ ] **Step 4: difit でレビュー依頼**
 
 Run:
+
 ```bash
 pnpm difit
 ```

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@hono/zod-validator": "^0.9.0",
     "@internationalized/date": "^3.12.2",
     "@marsidev/react-turnstile": "^1.5.3",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@opennextjs/cloudflare": "1.18.0",
     "@payloadcms/db-d1-sqlite": "3.84.1",
     "@payloadcms/live-preview-react": "3.84.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "reconnecting-websocket": "^4.4.0",
     "server-only": "^0.0.1",
     "shiki": "^4.2.0",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.13.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.1",
     "@gsap/react": "^2.1.2",
-    "@hono/zod-validator": "^0.7.6",
+    "@hono/zod-validator": "^0.9.0",
     "@internationalized/date": "^3.12.2",
     "@marsidev/react-turnstile": "^1.5.3",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.15.0)(react@19.2.7)
       '@hono/zod-validator':
-        specifier: ^0.7.6
-        version: 0.7.6(hono@4.12.23)(zod@3.25.76)
+        specifier: ^0.9.0
+        version: 0.9.0(hono@4.12.23)(zod@3.25.76)
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
@@ -2018,10 +2018,10 @@ packages:
       hono: '>=3.9.0'
       zod: ^3.19.1
 
-  '@hono/zod-validator@0.7.6':
-    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+  '@hono/zod-validator@0.9.0':
+    resolution: {integrity: sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug==}
     peerDependencies:
-      hono: '>=3.9.0'
+      hono: '>=4.11.2'
       zod: ^3.25.0 || ^4.0.0
 
   '@img/colour@1.1.0':
@@ -8301,7 +8301,7 @@ snapshots:
       hono: 4.12.23
       zod: 3.25.76
 
-  '@hono/zod-validator@0.7.6(hono@4.12.23)(zod@3.25.76)':
+  '@hono/zod-validator@0.9.0(hono@4.12.23)(zod@3.25.76)':
     dependencies:
       hono: 4.12.23
       zod: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,9 @@ importers:
       '@marsidev/react-turnstile':
         specifier: ^1.5.3
         version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@opennextjs/cloudflare':
         specifier: 1.18.0
         version: 1.18.0(next@15.3.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(wrangler@4.98.0)
@@ -2298,6 +2298,10 @@ packages:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -2307,6 +2311,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -8619,6 +8627,10 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.23)
@@ -8640,6 +8652,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@monaco-editor/loader@1.7.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 2.1.2(gsap@3.15.0)(react@19.2.7)
       '@hono/zod-validator':
         specifier: ^0.9.0
-        version: 0.9.0(hono@4.12.23)(zod@3.25.76)
+        version: 0.9.0(hono@4.12.23)(zod@4.4.3)
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
@@ -32,7 +32,7 @@ importers:
         version: 1.5.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@opennextjs/cloudflare':
         specifier: 1.18.0
         version: 1.18.0(next@15.3.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(wrangler@4.98.0)
@@ -112,8 +112,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.13.5
@@ -8301,10 +8301,10 @@ snapshots:
       hono: 4.12.23
       zod: 3.25.76
 
-  '@hono/zod-validator@0.9.0(hono@4.12.23)(zod@3.25.76)':
+  '@hono/zod-validator@0.9.0(hono@4.12.23)(zod@4.4.3)':
     dependencies:
       hono: 4.12.23
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@img/colour@1.1.0': {}
 
@@ -8618,28 +8618,6 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
-      jose: 6.2.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -13086,10 +13064,6 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
-
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/reports/2026-08-18-mcp-v2-migration-assessment.md
+++ b/reports/2026-08-18-mcp-v2-migration-assessment.md
@@ -11,13 +11,13 @@
 
 当初「2.0.0 beta」と見えていたが、npm 実測では **stable が出ている**。
 
-| パッケージ | 最新 | 備考 |
-| --- | --- | --- |
-| `@modelcontextprotocol/sdk` | 1.30.0 | v1 モノリス。**2.x は存在しない**(ここで打ち止め) |
-| `@modelcontextprotocol/core` | 2.0.0 | 公開 Zod スキーマ(spec + OAuth/OpenID)。deps: `zod ^4.2.0` |
-| `@modelcontextprotocol/server` | 2.0.0 | サーバ実装。deps: `zod ^4.2.0` + core |
-| `@modelcontextprotocol/client` | 2.0.0 | クライアント実装 |
-| `@modelcontextprotocol/hono` | 2.0.0 | **Hono アダプタ**。deps ゼロ / peer: `hono ^4.11.4` |
+| パッケージ                     | 最新   | 備考                                                       |
+| ------------------------------ | ------ | ---------------------------------------------------------- |
+| `@modelcontextprotocol/sdk`    | 1.30.0 | v1 モノリス。**2.x は存在しない**(ここで打ち止め)          |
+| `@modelcontextprotocol/core`   | 2.0.0  | 公開 Zod スキーマ(spec + OAuth/OpenID)。deps: `zod ^4.2.0` |
+| `@modelcontextprotocol/server` | 2.0.0  | サーバ実装。deps: `zod ^4.2.0` + core                      |
+| `@modelcontextprotocol/client` | 2.0.0  | クライアント実装                                           |
+| `@modelcontextprotocol/hono`   | 2.0.0  | **Hono アダプタ**。deps ゼロ / peer: `hono ^4.11.4`        |
 
 「v1 の `@modelcontextprotocol/sdk` を 2.x に上げる」という移行経路は存在しない。
 **パッケージを差し替える**移行になる。
@@ -70,10 +70,10 @@ Workers 前提のユーザーが想定されている証拠。
 v2 は **zod 3 を非サポート**。移行ガイドいわく zod@3 では
 「ツールが最初に list されたときに初めてエラーになる」= **サイレントに壊れる**。
 
-| 項目 | 現状 | 必要 |
-| --- | --- | --- |
-| `zod` | `^3.25.76` | `^4.2.0` |
-| `@hono/zod-validator` | `^0.7.6` | `^0.9.0`(peer: `zod ^3.25.0 \|\| ^4.0.0`) |
+| 項目                  | 現状       | 必要                                      |
+| --------------------- | ---------- | ----------------------------------------- |
+| `zod`                 | `^3.25.76` | `^4.2.0`                                  |
+| `@hono/zod-validator` | `^0.7.6`   | `^0.9.0`(peer: `zod ^3.25.0 \|\| ^4.0.0`) |
 
 zod を import しているのは 6 ファイル。うち MCP 以外が 4 つあり、そこが本当の作業量:
 
@@ -109,8 +109,8 @@ v2 移行で強制される変更はない。ただし v2 の認可強化で **D
 > 2026-08-18 追記: 1〜3 は型定義と実測で解消済み。残るは 4 のみ(実装時に検証)。
 
 1. ~~workerd 上でデフォルト validator のままで動くか~~ → **解消**。`jsonSchemaValidator` の既定は
-   型定義に *"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on
-   browser/workerd runtimes)"* と明記。**SDK がランタイムを自動判別する**ので手動注入は原則不要。
+   型定義に _"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on
+   browser/workerd runtimes)"_ と明記。**SDK がランタイムを自動判別する**ので手動注入は原則不要。
    `validators/cf-worker` はカスタマイズ用の口であって必須ではない。
 2. ~~`transport.handleRequest(request)` の第2引数が省略可能か~~ → **解消**。
    `handleRequest(req: Request, options?: HandleRequestOptions)` で optional。

--- a/reports/2026-08-18-mcp-v2-migration-assessment.md
+++ b/reports/2026-08-18-mcp-v2-migration-assessment.md
@@ -1,0 +1,145 @@
+# MCP v2 (2026-07-28) 移行アセスメント — 自前 MCP 実装
+
+- 日付: 2026-08-18
+- 対象: `src/lib/mcp` / `src/app/api/mcp/route.ts` / `worker/worker.ts`
+- 結論: **移行は現実的。しかも v2 の設計はうちのスタック(Hono + Workers)に寄っている。**
+  最大のコストは MCP そのものではなく **zod 3 → 4** の波及。
+- 前提: 公式 Payload plugin は採用不可と別途確定済み
+  (`reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md`)。v2 移行はそれとは独立に進められる。
+
+## 1. v2 は beta ではなく stable。パッケージは3分割された
+
+当初「2.0.0 beta」と見えていたが、npm 実測では **stable が出ている**。
+
+| パッケージ | 最新 | 備考 |
+| --- | --- | --- |
+| `@modelcontextprotocol/sdk` | 1.30.0 | v1 モノリス。**2.x は存在しない**(ここで打ち止め) |
+| `@modelcontextprotocol/core` | 2.0.0 | 公開 Zod スキーマ(spec + OAuth/OpenID)。deps: `zod ^4.2.0` |
+| `@modelcontextprotocol/server` | 2.0.0 | サーバ実装。deps: `zod ^4.2.0` + core |
+| `@modelcontextprotocol/client` | 2.0.0 | クライアント実装 |
+| `@modelcontextprotocol/hono` | 2.0.0 | **Hono アダプタ**。deps ゼロ / peer: `hono ^4.11.4` |
+
+「v1 の `@modelcontextprotocol/sdk` を 2.x に上げる」という移行経路は存在しない。
+**パッケージを差し替える**移行になる。
+
+## 2. うちにとって有利な点(実測)
+
+### 2-1. `WebStandardStreamableHTTPServerTransport` は v2 でも生きている
+
+`@modelcontextprotocol/hono` の README より:
+
+```ts
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+await server.connect(transport);
+
+const app = createMcpHonoApp();
+app.all('/mcp', c => transport.handleRequest(c.req.raw, { parsedBody: c.get('parsedBody') }));
+```
+
+現行 `src/app/api/mcp/route.ts` の骨格(`new McpServer` → tool 登録 →
+`new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined })` →
+`server.connect` → `transport.handleRequest(request)`)が **ほぼ 1:1 で移植できる**。
+v1 で `StreamableHTTPServerTransport`(Node 版)を使っていたら書き直しだったが、
+うちは最初から Web 標準側を選んでいたため、この選択が効いている。
+
+### 2-2. Node 依存がほぼ無い
+
+`@modelcontextprotocol/server@2.0.0` の dist が参照する Node ビルトインは `node:stream` のみ
+(stdio 系)。v1 の `mcp-handler` 経路が引いていた `http` / `net` / `redis` は無い。
+
+### 2-3. Workers 向けの validator が公式に用意されている
+
+`@modelcontextprotocol/server/validators/cf-worker` は Ajv(コード生成 = workerd の CSP で禁止)
+の代わりに `@cfworker/json-schema`(インタプリタ実装)を使う差し替え口。
+Workers 前提のユーザーが想定されている証拠。
+
+### 2-4. tool 登録は既に v2 の形
+
+リポジトリは既に `server.registerTool(name, { title, description, inputSchema, annotations }, handler)`
+を 12 箇所で使っている。v2 で削除されたのは可変長の `server.tool(...)` の方で、うちは非該当。
+必要なのは `inputSchema` の生シェイプを `z.object({ ... })` で包むことだけ(12 箇所、機械的)。
+
+## 3. 実際のコスト
+
+### 3-1. 最大の波及は zod 3 → 4
+
+v2 は **zod 3 を非サポート**。移行ガイドいわく zod@3 では
+「ツールが最初に list されたときに初めてエラーになる」= **サイレントに壊れる**。
+
+| 項目 | 現状 | 必要 |
+| --- | --- | --- |
+| `zod` | `^3.25.76` | `^4.2.0` |
+| `@hono/zod-validator` | `^0.7.6` | `^0.9.0`(peer: `zod ^3.25.0 \|\| ^4.0.0`) |
+
+zod を import しているのは 6 ファイル。うち MCP 以外が 4 つあり、そこが本当の作業量:
+
+```
+src/lib/mcp/tools/index.ts          ← MCP
+src/lib/mcp/tools/legal/index.ts    ← MCP
+src/app/api/media-upload/route.ts   ← 非 MCP
+src/lib/contact/schema.ts           ← 非 MCP
+src/lib/cursor/protocol.ts          ← 非 MCP
+worker/handlers/images/index.ts     ← 非 MCP
+```
+
+`@hono/zod-validator` 0.9.0 が zod 3/4 両対応なので、**先に validator だけ上げておけば
+zod 本体の切替を独立したステップに分離できる**。
+
+### 3-2. その他の差分(移行ガイドより)
+
+- ハンドラの第2引数が `extra` → 構造化された `ctx`(`extra.signal` → `ctx.mcpReq.signal` 等)
+- `setRequestHandler` が Zod スキーマ → メソッド文字列(`'tools/call'`)
+- エラー階層が `McpError` → `ProtocolError` / `SdkError` / `SdkHttpError`
+- ヘッダ読み出しが Web 標準 `.get()` に統一
+- 自動 codemod あり: `npx @modelcontextprotocol/codemod@latest v1-to-v2 .`
+
+### 3-3. OAuth 層は独立
+
+`worker/worker.ts` の `@cloudflare/workers-oauth-provider@0.8.1` は MCP SDK に依存しないので、
+v2 移行で強制される変更はない。ただし v2 の認可強化で **Dynamic Client Registration が
+正式に deprecated**(CIMD へ移行、サポート期間 12 ヶ月)。うちは `/oauth/register` = DCR を
+公開しているので、これは「今すぐ壊れないが期限のある watch item」。
+
+## 4. 未検証の項目(実装前に潰すべきもの)
+
+> 2026-08-18 追記: 1〜3 は型定義と実測で解消済み。残るは 4 のみ(実装時に検証)。
+
+1. ~~workerd 上でデフォルト validator のままで動くか~~ → **解消**。`jsonSchemaValidator` の既定は
+   型定義に *"Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on
+   browser/workerd runtimes)"* と明記。**SDK がランタイムを自動判別する**ので手動注入は原則不要。
+   `validators/cf-worker` はカスタマイズ用の口であって必須ではない。
+2. ~~`transport.handleRequest(request)` の第2引数が省略可能か~~ → **解消**。
+   `handleRequest(req: Request, options?: HandleRequestOptions)` で optional。
+3. ~~非 MCP 4 ファイルの zod 4 影響~~ → **ほぼ解消**。zod4 実測で `z` named / default export /
+   `.email({message})` / `.min(1,{message})` / `discriminatedUnion` / `error.flatten().fieldErrors`
+   がすべて v3 と同一に動作。ソース変更は不要の見込み(テストで最終確認)。
+4. v2 のステートレス化に伴い `Mcp-Method` / `Mcp-Name` ヘッダが増えることで、
+   `worker/app.ts` の `mcpGuardRoutes` や OAuth の `apiRoute: '/mcp'` 判定に影響が出ないか。
+   → **未検証**。実装計画の Task 5 で確認する。
+
+実装計画: `docs/superpowers/plans/2026-08-18-mcp-v2-migration.md`
+
+## 5. 推奨する進め方
+
+zod の切替と MCP の切替を**同時にやらない**のが要点。片方が壊れたときに切り分けられなくなる。
+
+```
+Step 1  @hono/zod-validator を 0.9.0 へ(zod 3/4 両対応になるだけ。挙動不変)
+Step 2  zod 3 → 4。6 ファイル + テスト。MCP には触らない
+Step 3  @modelcontextprotocol/sdk → @modelcontextprotocol/server + core。
+        codemod 実行 → inputSchema を z.object() で包む → 型を通す
+Step 4  workerd 実測(validators/cf-worker の要否、ガード/OAuth の疎通)
+Step 5  staging で実 OAuth 経路の E2E(既存の cloudflared 手順)
+```
+
+## 6. 急ぐ理由はあるか
+
+薄い。v1 の `@modelcontextprotocol/sdk@1.30.0` は現役で、うちのサーバは既に
+v2 の中心思想であるステートレス構成(`sessionIdGenerator: undefined` +
+Hono ガードによる前段認可)に到達している。ただし v1 モノリスは 1.30.0 で
+打ち止めの可能性が高く(2.x が別パッケージに移ったため)、**セキュリティ修正の供給が
+細る前に移る**というのが実際の動機になる。

--- a/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
+++ b/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
@@ -105,9 +105,11 @@ Payload が `/api` を前置するので `/api/mcp` 固定。本リポジトリ�
   ※ `initialize` ハンドシェイクや `Mcp-Session-Id` の仕組み自体は v2 の SDK から廃止されていない
   (`isInitializeRequest` / `sessionIdGenerator` は `@modelcontextprotocol/server` の
   `dist/index.mjs` に今も存在し、`sessionIdGenerator: () => crypto.randomUUID()` を渡せば
-  ステートフルにも動く)。`sessionIdGenerator: undefined` は SDK 自身のコメントも
-  「established stateless idiom, unchanged」と呼ぶ、v1 から続く一形態。加えて
-  `enableJsonResponse: true` で SSE ではなく素の JSON 応答にしている。
+  ステートフルにも動く)。`sessionIdGenerator` を省いた場合の挙動は SDK の型定義に
+  _"If not provided, session management is disabled (stateless mode)."_
+  (`@modelcontextprotocol/server/dist/index.d.mts:466`)と明記されている、
+  v1 から続く正規の使い方。加えて `enableJsonResponse: true` で SSE ではなく
+  素の JSON 応答にしている。
 - 認可は前段の Hono ガード(`worker/app.ts` の `mcpGuardRoutes`)が持つ
 
 v2 移行は Payload とは独立に進められる。

--- a/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
+++ b/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
@@ -23,11 +23,11 @@ compatibility_flags = ["nodejs_compat"]
 
 ## 結果
 
-| 段階 | 結果 | 備考 |
-| --- | --- | --- |
-| バンドル (`wrangler deploy --dry-run`) | ✅ | 2,323 KiB / gzip 459 KiB。`redis` `http` `net` は nodejs_compat の polyfill に解決される |
-| 起動 (module evaluation) | ✅ | ハンドラ内生成なら通る |
-| リクエスト処理 (`initialize`) | ❌ | **ハング**。7ms で workerd が打ち切り 500 |
+| 段階                                   | 結果 | 備考                                                                                     |
+| -------------------------------------- | ---- | ---------------------------------------------------------------------------------------- |
+| バンドル (`wrangler deploy --dry-run`) | ✅   | 2,323 KiB / gzip 459 KiB。`redis` `http` `net` は nodejs_compat の polyfill に解決される |
+| 起動 (module evaluation)               | ✅   | ハンドラ内生成なら通る                                                                   |
+| リクエスト処理 (`initialize`)          | ❌   | **ハング**。7ms で workerd が打ち切り 500                                                |
 
 ```
 [wrangler:info] POST /   404 Not Found (16ms)     ← ルーティングは生きている
@@ -52,7 +52,7 @@ assert  async_hooks  events  http  net  stream  redis
 
 本リポジトリの自前実装が `server/webStandardStreamableHttp.js`
 (Web 標準 Request/Response ベース)を直接使っているのは、まさにこれを避けるため。
-plugin 側に `withRestoredWebGlobals`(*"Restores globals replaced by @hono/node-server"*
+plugin 側に `withRestoredWebGlobals`(_"Restores globals replaced by @hono/node-server"_
 と書かれ、`globalThis.Request/Response` を書き戻すヘルパ)が存在すること自体が、
 Node サーバ前提の設計であることを示している。
 

--- a/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
+++ b/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
@@ -1,0 +1,129 @@
+# `@payloadcms/plugin-mcp` 評価 — Cloudflare Workers 上で採用可能か
+
+- 日付: 2026-08-18
+- 目的: 公式 MCP plugin を `logs` collection で試し、自前 MCP 実装(`src/lib/mcp`, 約 4,800 行)を
+  どこまで置き換えられるかを評価する
+- 結論: **現時点では採用不可**。技術的な良し悪し以前に、Cloudflare Workers(workerd)上で
+  リクエストが処理できない。`payload` の 3.88.0 への bump も行っていない(不要と判明したため)。
+
+## 検証環境
+
+リポジトリ本体には一切変更を加えていない。scratchpad に最小 Worker を作り、
+`wrangler.toml` の compat 設定だけ本体と一致させた。
+
+```toml
+compatibility_date = "2025-08-15"
+compatibility_flags = ["nodejs_compat"]
+```
+
+プローブは `plugin-mcp` の `endpoints/mcp.js` と同じ呼び出し形
+(`createMcpHandler` をモジュールトップレベルではなくリクエストハンドラ内で生成)を再現した。
+この差は結果を分けるので重要 —— トップレベル生成では workerd の
+「グローバルスコープで乱数生成・非同期 I/O 禁止」に触れて起動すらしない。
+
+## 結果
+
+| 段階 | 結果 | 備考 |
+| --- | --- | --- |
+| バンドル (`wrangler deploy --dry-run`) | ✅ | 2,323 KiB / gzip 459 KiB。`redis` `http` `net` は nodejs_compat の polyfill に解決される |
+| 起動 (module evaluation) | ✅ | ハンドラ内生成なら通る |
+| リクエスト処理 (`initialize`) | ❌ | **ハング**。7ms で workerd が打ち切り 500 |
+
+```
+[wrangler:info] POST /   404 Not Found (16ms)     ← ルーティングは生きている
+[wrangler:info] POST /mcp 500 Internal Server Error (7ms)
+✘ [ERROR] Uncaught Error: The Workers runtime canceled this request because it
+  detected that your Worker's code had hung and would never generate a response.
+```
+
+### 原因
+
+`mcp-handler@1.0.7` のエントリが静的 import している外部モジュール:
+
+```
+assert  async_hooks  events  http  net  stream  redis
+@modelcontextprotocol/sdk/server/streamableHttp.js   ← Node 版 transport
+@modelcontextprotocol/sdk/server/sse.js
+```
+
+`server/streamableHttp.js` は `http.ServerResponse` に書き込む Node 専用 transport。
+`nodejs_compat` の `node:http` にはサーバ側(`createServer` / `ServerResponse`)の
+実体がないため、レスポンスが完成せずハングする。
+
+本リポジトリの自前実装が `server/webStandardStreamableHttp.js`
+(Web 標準 Request/Response ベース)を直接使っているのは、まさにこれを避けるため。
+plugin 側に `withRestoredWebGlobals`(*"Restores globals replaced by @hono/node-server"*
+と書かれ、`globalThis.Request/Response` を書き戻すヘルパ)が存在すること自体が、
+Node サーバ前提の設計であることを示している。
+
+## 併せて判明した阻害要因
+
+### 1. endpoint パスが固定で、既存ルートと衝突する
+
+`dist/index.js` でパスはハードコードされており、設定できるのは `disabled` のみ:
+
+```js
+config.endpoints.push({ handler: initializeMCPHandler(pluginOptions), method: 'post', path: '/mcp' })
+config.endpoints.push({ handler: initializeMCPHandler(pluginOptions), method: 'get',  path: '/mcp' })
+```
+
+Payload が `/api` を前置するので `/api/mcp` 固定。本リポジトリには明示ルート
+`src/app/api/mcp/route.ts` があり、App Router では明示セグメントが
+`(payload)/api/[...slug]` より優先されるため、plugin の endpoint には到達しない。
+共存には自前ルートの退避が必要。
+
+### 2. `payload` の peerDependency が完全一致ピン
+
+```json
+"peerDependencies": { "payload": "3.88.0" }
+```
+
+本リポジトリは `payload` / `@payloadcms/*` が全て `3.84.1`。試用するだけでも
+4 マイナー分の bump が前提になる。
+
+### 3. plugin 自身の依存ツリーに peer 不整合がある
+
+`mcp-handler@1.0.7` の peer は `@modelcontextprotocol/sdk@"1.25.2"`(完全一致ピン)
+だが、plugin は `1.30.0` を dependencies に持つ。npm では `--legacy-peer-deps` 無しに
+インストールできない。
+
+## MCP v2 (2026-07-28) との関係
+
+「公式 plugin に寄せる」と「MCP v2 に移行する」は**別方向の話**である。
+
+- plugin が使う SDK は `1.30.0` = v1 系(protocol `2025-11-25`)。
+- v2 対応は TS SDK **2.0.0 beta** から(スキーマが `@modelcontextprotocol/core` に分離)。
+  npm の `latest` は現在も 1.30.0。
+- したがって plugin に寄せることは、v2 対応を Payload 側の bump 待ちにする選択になる。
+
+一方、v2 の中心であるステートレス化(`initialize` ハンドシェイク廃止、`Mcp-Session-Id` 廃止、
+method/tool 名を HTTP ヘッダへ出してゲートウェイで認可)は、本リポジトリでは
+**既に手で到達している**:
+
+- `src/app/api/mcp/route.ts` — `sessionIdGenerator: undefined` / `enableJsonResponse: true`
+- 認可は前段の Hono ガード(`worker/app.ts` の `mcpGuardRoutes`)が持つ
+
+v2 移行は Payload とは独立に進められる。
+
+## 判断
+
+- **公式 plugin は現状採用しない。** 理由はランタイム互換であり、tool 設計の良し悪しではない。
+- 採用可能になる条件は `mcp-handler` が Web 標準 transport に移行すること
+  (もしくは plugin が `mcp-handler` 依存をやめること)。それまで再評価しても結果は変わらない。
+- `payload` 3.88.0 への bump は、この件を理由に急ぐ必要はない。
+- `logs` に MCP ツールが欲しい場合は、既存の自前 MCP(`src/lib/mcp/tools`)に追加するのが唯一の道。
+  `logs` は richText を持たないフラットな collection なので、Markdown codec 層は不要で、
+  `legal` ツール(`src/lib/mcp/tools/legal`)が最も近い雛形になる。
+
+## 再現手順
+
+```bash
+# scratchpad/stage0 に最小 Worker を作り、本体の compat 設定に揃える
+npm install --legacy-peer-deps           # mcp-handler@1.0.7 + @modelcontextprotocol/sdk@1.30.0
+npx wrangler deploy --dry-run --outdir=dist   # ← 通る
+npx wrangler dev --port 8799 --local          # ← 起動する
+curl -X POST http://127.0.0.1:8799/mcp \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
+# ← ハングして 500
+```

--- a/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
+++ b/reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md
@@ -92,15 +92,22 @@ Payload が `/api` を前置するので `/api/mcp` 固定。本リポジトリ�
 「公式 plugin に寄せる」と「MCP v2 に移行する」は**別方向の話**である。
 
 - plugin が使う SDK は `1.30.0` = v1 系(protocol `2025-11-25`)。
-- v2 対応は TS SDK **2.0.0 beta** から(スキーマが `@modelcontextprotocol/core` に分離)。
-  npm の `latest` は現在も 1.30.0。
+- v2 対応は TS SDK **2.0.0(stable)** から(スキーマが `@modelcontextprotocol/core` に分離)。
+  npm 実測: `@modelcontextprotocol/core` / `/server` / `/client` / `/hono` はいずれも `2.0.0` が
+  publish 済み。npm の `latest`(`@modelcontextprotocol/sdk`)は今も `1.30.0` の v1 モノリスで、
+  v2 とは別パッケージ系列(詳細は `reports/2026-08-18-mcp-v2-migration-assessment.md`)。
 - したがって plugin に寄せることは、v2 対応を Payload 側の bump 待ちにする選択になる。
 
-一方、v2 の中心であるステートレス化(`initialize` ハンドシェイク廃止、`Mcp-Session-Id` 廃止、
-method/tool 名を HTTP ヘッダへ出してゲートウェイで認可)は、本リポジトリでは
-**既に手で到達している**:
+一方、v2 の設計が志向するステートレス運用(method/tool 名を HTTP ヘッダへ出してゲートウェイで
+認可する構成)は、本リポジトリでは**既に手で到達している**:
 
-- `src/app/api/mcp/route.ts` — `sessionIdGenerator: undefined` / `enableJsonResponse: true`
+- `src/app/api/mcp/route.ts` — `sessionIdGenerator: undefined` でステートレスに動かしている。
+  ※ `initialize` ハンドシェイクや `Mcp-Session-Id` の仕組み自体は v2 の SDK から廃止されていない
+  (`isInitializeRequest` / `sessionIdGenerator` は `@modelcontextprotocol/server` の
+  `dist/index.mjs` に今も存在し、`sessionIdGenerator: () => crypto.randomUUID()` を渡せば
+  ステートフルにも動く)。`sessionIdGenerator: undefined` は SDK 自身のコメントも
+  「established stateless idiom, unchanged」と呼ぶ、v1 から続く一形態。加えて
+  `enableJsonResponse: true` で SSE ではなく素の JSON 応答にしている。
 - 認可は前段の Hono ガード(`worker/app.ts` の `mcpGuardRoutes`)が持つ
 
 v2 移行は Payload とは独立に進められる。

--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -16,13 +16,11 @@ vi.mock('@payloadcms/richtext-lexical', () => ({
   CodeBlock: () => ({ slug: 'Code', fields: [] }),
   lexicalEditor: () => ({}),
 }));
-vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+vi.mock('@modelcontextprotocol/server', () => ({
   McpServer: class {
     registerTool(): void {}
     async connect(): Promise<void> {}
   },
-}));
-vi.mock('@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js', () => ({
   WebStandardStreamableHTTPServerTransport: class {
     async handleRequest(): Promise<Response> {
       return new Response('{}', { status: 200 });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -2,6 +2,7 @@ import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { editorConfigFactory } from '@payloadcms/richtext-lexical';
 
 import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
 
 import { createMarkdownCodec } from '@lib/mcp/markdown';
 import { registerBlogTools } from '@lib/mcp/tools';
@@ -56,7 +57,20 @@ const handleMCPRequest = async (request: Request): Promise<Response> => {
   // 元は SDK v1(@modelcontextprotocol/sdk 1.26+)で確認した制約だが、v2
   // (@modelcontextprotocol/server 2.0.0)でも同じ。実挙動は workerd 上の
   // worker/mcp-v2-runtime.test.ts が毎回この形で組み直して固定している。
-  const server = new McpServer({ name: 'napochaan-blog', version: '1.0.0' });
+  // jsonSchemaValidator を明示注入する理由: SDK の既定バリデータは実行時のランタイム判定では
+  // なく、`@modelcontextprotocol/server` の `"./_shims"` エントリの **ビルド時 export condition**
+  // (`workerd` | `browser` | `node` | `default`=node)で選ばれる。Next の webpack ビルドは
+  // `node` を解決するため、無指定だと本番バンドルには Ajv(`AjvJsonSchemaValidator`)が入る。
+  // Ajv はスキーマのコンパイルに `new Function(...)` を使うが、workerd はコード生成を禁止して
+  // おり(`EvalError: Code generation from strings disallowed`)、Ajv 経路のツールを呼んだ瞬間に
+  // 本番で 500 になる。`worker/mcp-v2-runtime.test.ts` はこの分岐を検知できない —
+  // vitest の workers pool(`@cloudflare/vitest-pool-workers`)は `workerd` condition を解決する
+  // ため、同じコードでもテストでは自動的に `@cfworker/json-schema` ベースの Workers 版が選ばれて
+  // しまい、Next ビルドで実際に何が入るかとは無関係にグリーンになる。
+  // ここで明示的に Workers 版を注入すれば、ビルドツールの export condition 解決に依存せず
+  // Node/Workers 双方で同じバリデータが使われる(`@cfworker/json-schema` はこのパッケージに
+  // 同梱済みなので依存追加は不要)。
+  const server = new McpServer({ name: 'napochaan-blog', version: '1.0.0' }, { jsonSchemaValidator: new CfWorkerJsonSchemaValidator() });
   registerBlogTools(server, {
     payload,
     user,

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,8 +1,7 @@
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { editorConfigFactory } from '@payloadcms/richtext-lexical';
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 import { createMarkdownCodec } from '@lib/mcp/markdown';
 import { registerBlogTools } from '@lib/mcp/tools';

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -51,8 +51,11 @@ const handleMCPRequest = async (request: Request): Promise<Response> => {
   // 再利用する(専用 secret を新設せず、既存の秘匿値を流用する設計判断)。
   const { env } = await getCloudflareContext({ async: true });
 
-  // MCP SDK 1.26+ はリクエストごとに server / transport を新規生成する必要がある
-  // (共有すると "already connected" で throw する)。生成は安価。
+  // server / transport はリクエストごとに新規生成する必要がある(共有すると
+  // "already connected" で throw する)。生成は安価。
+  // 元は SDK v1(@modelcontextprotocol/sdk 1.26+)で確認した制約だが、v2
+  // (@modelcontextprotocol/server 2.0.0)でも同じ。実挙動は workerd 上の
+  // worker/mcp-v2-runtime.test.ts が毎回この形で組み直して固定している。
   const server = new McpServer({ name: 'napochaan-blog', version: '1.0.0' });
   registerBlogTools(server, {
     payload,

--- a/src/lib/mcp/tools/index.ts
+++ b/src/lib/mcp/tools/index.ts
@@ -32,7 +32,7 @@ import type { MarkdownCodec } from '../markdown';
 import type { ImageNode, ImageRef, InlineNode } from '../markdown/image-ref';
 import type { MediaHit } from './raw-ref-hints';
 import type { ToolResult } from './shared/tool-result';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { Result, ResultAsync } from 'neverthrow';
 import type { Blog, User } from '@payload-types';
 import type { Payload } from 'payload';

--- a/src/lib/mcp/tools/legal/index.ts
+++ b/src/lib/mcp/tools/legal/index.ts
@@ -14,7 +14,7 @@ import type { McpToolError } from '../../errors';
 import type { MarkdownCodec } from '../../markdown';
 import type { ToolResult } from '../shared/tool-result';
 import type { Validator } from '@utils/run-validators';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { LegalDocument, User } from '@payload-types';
 import type { Result, ResultAsync } from 'neverthrow';
 import type { Payload } from 'payload';

--- a/worker/mcp-v2-runtime.test.ts
+++ b/worker/mcp-v2-runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+
+// v1 では mcp-handler が Node 版 transport を掴んでいたため workerd 上でリクエストが
+// ハングした(reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md)。
+// route.test.ts は SDK を vi.mock しているのでこの層を守れない。ここだけが
+// 「実物の SDK が workerd で動く」ことを保証している。消さないこと。
+const buildRequest = (body: unknown): Request =>
+  new Request('https://example.test/api/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+    body: JSON.stringify(body),
+  });
+
+const handle = async (body: unknown): Promise<Response> => {
+  const server = new McpServer({ name: 'runtime-probe', version: '1.0.0' });
+  server.registerTool('echo', { title: 'echo', description: 'workerd 実行確認用', inputSchema: { value: z.string() } }, ({ value }) => ({ content: [{ type: 'text' as const, text: value }] }));
+  const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true });
+  await server.connect(transport);
+  return transport.handleRequest(buildRequest(body));
+};
+
+describe('MCP v2 SDK on workerd', () => {
+  it('responds to tools/list without hanging', async () => {
+    const response = await handle({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { result?: { tools?: { name: string }[] } };
+    expect(payload.result?.tools?.map((tool) => tool.name)).toContain('echo');
+  });
+
+  it('executes a tool call', async () => {
+    const response = await handle({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'echo', arguments: { value: 'ok' } } });
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as { result?: { content?: { text?: string }[] } };
+    expect(payload.result?.content?.[0]?.text).toBe('ok');
+  });
+});

--- a/worker/mcp-v2-runtime.test.ts
+++ b/worker/mcp-v2-runtime.test.ts
@@ -37,6 +37,15 @@ const handle = async (body: unknown): Promise<Response> => {
 };
 
 describe('MCP v2 SDK on workerd', () => {
+  // このファイル自体が実 workerd 上で走っている前提(コメント末尾を参照)が崩れると、
+  // 以下の全テストは「実は何も守っていない」状態にサイレントに退化する。
+  // vitest workers pool は `navigator.userAgent` を固定値 'Cloudflare-Workers' にしている
+  // (実測、@cloudflare/vitest-pool-workers)。`worker/**` が将来 node pool に移設される等の
+  // config 変更が起きたら、このテストごと壊れて気づけるようにする。
+  it('runs on workerd, not node', () => {
+    expect(navigator.userAgent).toContain('Cloudflare-Workers');
+  });
+
   it(
     'responds to tools/list without hanging',
     async () => {
@@ -63,11 +72,16 @@ describe('MCP v2 SDK on workerd', () => {
     HANG_DETECTION_TIMEOUT_MS,
   );
 
-  // 意図的に custom jsonSchemaValidator を注入していない: workerd 上では SDK が
-  // @cfworker/json-schema ベースのバリデータを自動選択する想定に依存している。
-  // ここまでのテストは全て schema に適合した引数しか送っておらず、バリデータが
-  // 無害な no-op にすり替わっていても検知できない。schema 違反の引数(value に
-  // number)を送り、実際に拒否されることを確認する。
+  // 注意: この negative case が固定しているのは **zod-shape の tool 入力検証**であって、
+  // JSON-Schema バリデータ(Ajv / CfWorkerJsonSchemaValidator)ではない。registerTool の
+  // inputSchema は raw な Zod shape で渡しており、tools/call の引数検証は McpServer 内部で
+  // 直接 zod によって行われる(fromJsonSchema 経由の JSON-Schema 検証を経由しない)。
+  // つまりこのテストは JSON-Schema バリデータが不在でも全く同じ結果になり、
+  // `src/app/api/mcp/route.ts` の `jsonSchemaValidator` 明示注入(elicitInput 等が使う経路)
+  // は一切守っていない。
+  // ここまでのテストは全て schema に適合した引数しか送っておらず、この negative case は
+  // 「zod バリデータが無害な no-op にすり替わっていても検知できない」という穴を zod 経路に
+  // 限って塞ぐもの。schema 違反の引数(value に number)を送り、実際に拒否されることを確認する。
   //
   // 実測(workerd, @modelcontextprotocol/server v2): HTTP status は 200 のままで、
   // JSON-RPC の error 封筒は付かない。バリデーションエラーは

--- a/worker/mcp-v2-runtime.test.ts
+++ b/worker/mcp-v2-runtime.test.ts
@@ -7,6 +7,20 @@ import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelconte
 // ハングした(reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md)。
 // route.test.ts は SDK を vi.mock しているのでこの層を守れない。ここだけが
 // 「実物の SDK が workerd で動く」ことを保証している。消さないこと。
+//
+// 各テストに明示的な timeout(第3引数)を付けている理由: この transport.handleRequest が
+// 二度とハングしないと保証するのがこのファイルの存在意義そのもの。await が解決しなければ
+// assertion は一切実行されず、テストを失敗させる唯一の仕組みが vitest のグローバル既定
+// timeout(5000ms)になってしまう — それはどこか別の設定ファイルで変更されうる値であり、
+// ハング検知をそこに依存させてはならない。だから timeout は各 it() にこの場で明示する。
+// 削除しないこと。
+const HANG_DETECTION_TIMEOUT_MS = 10_000;
+
+// JSON-RPC のエラー封筒。HTTP 200 のまま { error: {...} } が返るケースを先に弾くための型。
+type JsonRpcErrorEnvelope = {
+  error?: { code: number; message: string };
+};
+
 const buildRequest = (body: unknown): Request =>
   new Request('https://example.test/api/mcp', {
     method: 'POST',
@@ -23,19 +37,52 @@ const handle = async (body: unknown): Promise<Response> => {
 };
 
 describe('MCP v2 SDK on workerd', () => {
-  it('responds to tools/list without hanging', async () => {
-    const response = await handle({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+  it(
+    'responds to tools/list without hanging',
+    async () => {
+      const response = await handle({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
 
-    expect(response.status).toBe(200);
-    const payload = (await response.json()) as { result?: { tools?: { name: string }[] } };
-    expect(payload.result?.tools?.map((tool) => tool.name)).toContain('echo');
-  });
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as JsonRpcErrorEnvelope & { result?: { tools?: { name: string }[] } };
+      expect(payload.error).toBeUndefined();
+      expect(payload.result?.tools?.map((tool) => tool.name)).toContain('echo');
+    },
+    HANG_DETECTION_TIMEOUT_MS,
+  );
 
-  it('executes a tool call', async () => {
-    const response = await handle({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'echo', arguments: { value: 'ok' } } });
+  it(
+    'executes a tool call',
+    async () => {
+      const response = await handle({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'echo', arguments: { value: 'ok' } } });
 
-    expect(response.status).toBe(200);
-    const payload = (await response.json()) as { result?: { content?: { text?: string }[] } };
-    expect(payload.result?.content?.[0]?.text).toBe('ok');
-  });
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as JsonRpcErrorEnvelope & { result?: { content?: { text?: string }[] } };
+      expect(payload.error).toBeUndefined();
+      expect(payload.result?.content?.[0]?.text).toBe('ok');
+    },
+    HANG_DETECTION_TIMEOUT_MS,
+  );
+
+  // 意図的に custom jsonSchemaValidator を注入していない: workerd 上では SDK が
+  // @cfworker/json-schema ベースのバリデータを自動選択する想定に依存している。
+  // ここまでのテストは全て schema に適合した引数しか送っておらず、バリデータが
+  // 無害な no-op にすり替わっていても検知できない。schema 違反の引数(value に
+  // number)を送り、実際に拒否されることを確認する。
+  //
+  // 実測(workerd, @modelcontextprotocol/server v2): HTTP status は 200 のままで、
+  // JSON-RPC の error 封筒は付かない。バリデーションエラーは
+  // result.isError === true と result.content[0].text の文言として表現される。
+  it(
+    'rejects a tool call with schema-invalid arguments',
+    async () => {
+      const response = await handle({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'echo', arguments: { value: 123 } } });
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as JsonRpcErrorEnvelope & { result?: { content?: { text?: string }[]; isError?: boolean } };
+      expect(payload.error).toBeUndefined();
+      expect(payload.result?.isError).toBe(true);
+      expect(payload.result?.content?.[0]?.text).toContain('Invalid arguments for tool echo');
+    },
+    HANG_DETECTION_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
自前 MCP サーバを v1 モノリス `@modelcontextprotocol/sdk@1.29.0` から v2 の `@modelcontextprotocol/server@2.0.0` へ移行する。併せて v2 が要求する zod 4 へ上げる。

## 発端

「Payload に公式の MCP plugin があるなら `logs` で試したい」という調査から始まった。結論は **公式 `@payloadcms/plugin-mcp` は採用不可**。

workerd 上でバンドルも起動も通るが、**最初のリクエストでハングする**（7ms で workerd が打ち切り 500）。原因は `mcp-handler` が SDK の Node 版 `streamableHttp` transport を静的 import していること — `http.ServerResponse` に書き込む実装で、`nodejs_compat` の `node:http` にはサーバ側の実体がないためレスポンスが完成しない。

副次的な阻害要因も3つあった: endpoint パスが `/api/mcp` ハードコードで自前ルートと衝突 / peerDeps が `payload: "3.88.0"` 完全一致ピン（本リポジトリは 3.84.1） / plugin 自身の peer 不整合。

詳細と再現手順: `reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md`

## 移行方針

破壊の原因を1つに特定できるよう、依存の昇格を3段階に分離した。

1. `@hono/zod-validator` → `^0.9.0`（peer が `zod ^3.25.0 || ^4.0.0` の両対応になる）
2. `zod` → `^4.4.3`
3. SDK → `@modelcontextprotocol/server@^2.0.0`

**1 と 2 はソース変更ゼロ**で完了した（zod 4 の破壊的変更が本リポジトリに当たらないことを事前に実測済み）。そのため 3 で何か壊れたら原因は SDK 差し替え以外にあり得ない、という状態を作れた。

v1 の時点で `WebStandardStreamableHTTPServerTransport`（Web 標準 Request/Response）を選んでいたおかげで、v2 でも同一 API がそのまま使える。`registerTool` の 12 箇所も `handleRequest(request)` の呼び出しも無変更。

## 変更の実体

ソース変更は実質 `src/app/api/mcp/route.ts` 1 ファイルと、型 import 2 行、テストの `vi.mock` 統合だけ。残りは新規テストと依存定義とドキュメント。

## ⚠️ 最も重要な修正: JSON Schema validator の明示注入

当初「SDK が workerd を自動判別する」と判断して validator の注入を見送ったが、**これは誤りだった**。

選択はランタイム判定ではなく `@modelcontextprotocol/server` の `"./_shims"` エントリの **ビルド時 export condition**（`workerd` | `browser` | `node` | `default`=node）で決まる。

- vitest の workers pool は `workerd` を解決 → テストは `@cfworker/json-schema` で緑になる
- **Next の webpack は `node` を解決** → 本番バンドルには AJV が入っていた

AJV はスキーマのコンパイルに `new Function()` を使うが workerd はコード生成を禁止しているため、AJV 経路のツール（`elicitInput` 等）を呼んだ瞬間に本番 500 になる。現時点では 12 個のツールが全て ZodRawShape 経由なので到達しないが、潜在的な地雷だった。

最終レビューが `.next/server/app/api/mcp/route.js` を grep して `AjvJsonSchemaValidator` を発見。`route.ts` で `jsonSchemaValidator: new CfWorkerJsonSchemaValidator()` を明示注入し、バンドラの export condition 解決に依存しない形にした。修正後の本番バンドルで `CfWorkerJsonSchemaValidator` が 0 → 1 になることを確認済み。

## テスト

`worker/mcp-v2-runtime.test.ts` を新設した。`src/app/api/mcp/route.test.ts` は MCP パッケージを丸ごと `vi.mock` しているため、**実物の SDK が実 workerd で動くことを検証している唯一の場所**になる（`worker/**/*.test.ts` は `@cloudflare/vitest-pool-workers` 経由で本物の workerd 上で実行される）。公式 plugin がハングしたのと同じ層に対する回帰ネット。

- ハング検知は明示タイムアウトで固定（グローバル既定に依存しない）
- schema 違反入力の negative case あり（zod パスの検証を pin）
- workerd 上で走っていること自体をアサート（node pool へ移されたら落ちる）

## 検証

- `pnpm test` 1482 pass / 1 skip / 0 fail（ベースライン 1478 → +4 は全て新規テスト）
- `pnpm lint` / `pnpm typecheck` clean
- `next build` 成功 / `opennextjs-cloudflare build` 成功
- ガード境界（`/api/mcp` の外部遮断）健在。v2 の `Mcp-Method` / `Mcp-Name` ヘッダ追加は無影響
- `@modelcontextprotocol/sdk` の残存参照ゼロ

セキュリティ境界は最終レビューで実ビルドに対するバイパス試行込みで確認済み（`/api/%6Dcp`・`/api/./mcp`・`//api/mcp`・`/API/mcp`・`/api/mcp%2Fx`。`worker/worker.ts` が `x-mcp-user-id` を `.set()` で上書きするためクライアント指定値は OAuth 経路を生き延びない）。

## 残件

- **staging E2E（リリースゲート）**: 実 OAuth 経路は未検証。12 個の実ツールスキーマの JSON Schema 変換は staging の最初の `tools/list` で担保する。merge ブロッカーではないとレビュー判定。
- **`durabcast` の zod 二重解決**: 移行前から存在する既存事象。MCP 側とは物理的に別インスタンス。backlog。
- **DCR の deprecated 化**: v2 で `/oauth/register` が非推奨（サポート 12ヶ月）。期限付き watch item としてレポートに記録。

## ドキュメント

- `reports/2026-08-18-payload-plugin-mcp-workerd-evaluation.md` — plugin 不採用の判断根拠と再現手順
- `reports/2026-08-18-mcp-v2-migration-assessment.md` — v2 移行コストの調査
- `docs/superpowers/plans/2026-08-18-mcp-v2-migration.md` — 実装計画

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT4nqdBLcsC482v6PTuo6s