### PR TITLE
feat(mcp): add logs collection tools (list / create / update / publish / delete)

### DIFF
--- a/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
@@ -607,7 +607,8 @@ const parseDate = (value: string): ResultAsync<string, McpToolError> => validate
             payload.create({
               collection: 'logs',
               draft: true,
-              data: { title: input.title, date: input.date, meta: input.meta, url: input.url },
+              // `draft: true` に加えて `_status: 'draft'` も明示する(legal の createLegalDocument と同じ)。
+              data: { title: input.title, date: input.date, meta: input.meta, url: input.url, _status: 'draft' },
               overrideAccess: false,
               user,
             }),

--- a/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
@@ -4,7 +4,7 @@
 
 **Goal:** `/log` の年表に載る手動エントリ(`logs` collection)を MCP から追加・編集・公開・削除できるようにする。
 
-**Architecture:** `src/lib/mcp/tools/legal` を雛形に `src/lib/mcp/tools/logs` を新設する。`logs` は richText を持たないため Markdown codec 層は不要で、`LogToolDeps` は `{ payload, user }` のみ。ハンドラは neverthrow の `ResultAsync` チェーンで組み、`.match(ok, toToolError)` で終端する。`meta` の選択肢は collection から export して単一ソース化する。
+**Architecture:** `src/lib/mcp/tools/legal` を雛形に `src/lib/mcp/tools/logs` を新設する。`logs` は richText を持たないため Markdown codec 層は不要で、`LogToolDeps` は `{ payload, user }` のみ。ハンドラは neverthrow の `ResultAsync` チェーンで組み、`.match(ok, toToolError)` で終端する。`meta` の選択肢は依存ゼロの葉モジュール `src/collections/fields/log-meta` を単一の出所とし、collection の `options` も MCP の `z.enum` もそこから導出する。
 
 **Tech Stack:** Payload CMS 3.84.1 / `@modelcontextprotocol/server` 2.0.0 / zod 4 / neverthrow / vitest / `@utils/dayjs`
 
@@ -13,7 +13,7 @@
 - ツールは 5 つ: `list_logs` / `create_log` / `update_log` / `publish_log` / `delete_log`
 - `create_log` は必ず `_status: 'draft'` で作る。公開は `publish_log` のみ
 - `delete_log` は **`id` のみ**。title 照合は入れない(本人決定 2026-08-18)
-- `meta` の正準値は `src/collections/logs.ts` の `LOG_META_OPTIONS` ただ一つ。MCP 側にリテラルを複製しない
+- `meta` の正準値は `src/collections/fields/log-meta` の `LOG_META_OPTIONS` ただ一つ。MCP 側にも collection 側にもリテラルを複製しない(どちらも導出する)
 - 日付は `YYYY-MM-DD` 固定。検証は `@utils/dayjs` の strict parse。生の `Date` / `Intl` / `slice` 禁止(`.claude/rules/dayjs-timezone.md`)
 - write path は strict。不正入力は**変換せず reject** し、①何が不正か ②有効な選択肢の全列挙 ③問題の値 ④回避手段 を含む回復ヒントを返す(`.claude/rules/mcp-write-strict.md`)
 - 関数は arrow function。`let` / IIFE / 非 null assertion `!` / `forEach` / `any` 禁止

--- a/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
@@ -18,6 +18,10 @@
 - write path は strict。不正入力は**変換せず reject** し、①何が不正か ②有効な選択肢の全列挙 ③問題の値 ④回避手段 を含む回復ヒントを返す(`.claude/rules/mcp-write-strict.md`)
 - 関数は arrow function。`let` / IIFE / 非 null assertion `!` / `forEach` / `any` 禁止
 - `Boolean()` / `String()` / `Number()` 禁止。`parseInt(x, 10)` / テンプレートリテラル / 明示的な `!==` を使う
+- tsconfig は `noUncheckedIndexedAccess` が有効。テストでも配列の添字アクセスは
+  `result.content[0]?.text ?? ''` の形にする(`const [{ text }] = ...` や
+  `result.content[0].text` は typecheck に落ちる)。`pnpm exec vitest run` は
+  型検査をしないので単体では気づけない — **必ず `pnpm typecheck` まで通すこと**
 - 各タスク完了時に `pnpm lint && pnpm typecheck` を通す。`npx tsc` は使わない
 - commit はタスク毎に行う。push と PR はしない
 
@@ -482,8 +486,8 @@ describe('createLog', () => {
     const result = await handlers.createLog({ title: 'x', date: '2026/11/01', meta: 'DJ' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('YYYY-MM-DD');
-    expect(result.content[0].text).toContain('2026/11/01');
+    expect(result.content[0]?.text ?? '').toContain('YYYY-MM-DD');
+    expect(result.content[0]?.text ?? '').toContain('2026/11/01');
     expect(payload.create).not.toHaveBeenCalled();
   });
 
@@ -519,7 +523,7 @@ describe('updateLog', () => {
     const result = await handlers.updateLog({ id: 999, title: '新' });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('list_logs');
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
     expect(payload.update).not.toHaveBeenCalled();
   });
 });
@@ -756,7 +760,7 @@ describe('publishLog', () => {
     const result = await handlers.publishLog({ id: 999 });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('list_logs');
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
     expect(payload.update).not.toHaveBeenCalled();
   });
 });
@@ -772,7 +776,7 @@ describe('deleteLog', () => {
 
     expect(result.isError).toBeUndefined();
     expect(payload.delete).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, overrideAccess: false, user }));
-    expect(JSON.parse(result.content[0].text)).toEqual(expect.objectContaining({ id: 9, title: '消す対象' }));
+    expect(JSON.parse(result.content[0]?.text ?? '')).toEqual(expect.objectContaining({ id: 9, title: '消す対象' }));
   });
 
   it('存在しない id は回復ヒント付きで reject し、delete しない', async () => {
@@ -783,7 +787,7 @@ describe('deleteLog', () => {
     const result = await handlers.deleteLog({ id: 999 });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('list_logs');
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
     expect(payload.delete).not.toHaveBeenCalled();
   });
 });

--- a/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
+++ b/docs/superpowers/plans/2026-08-18-logs-mcp-tools.md
@@ -1,0 +1,973 @@
+# logs collection の MCP ツール 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/log` の年表に載る手動エントリ(`logs` collection)を MCP から追加・編集・公開・削除できるようにする。
+
+**Architecture:** `src/lib/mcp/tools/legal` を雛形に `src/lib/mcp/tools/logs` を新設する。`logs` は richText を持たないため Markdown codec 層は不要で、`LogToolDeps` は `{ payload, user }` のみ。ハンドラは neverthrow の `ResultAsync` チェーンで組み、`.match(ok, toToolError)` で終端する。`meta` の選択肢は collection から export して単一ソース化する。
+
+**Tech Stack:** Payload CMS 3.84.1 / `@modelcontextprotocol/server` 2.0.0 / zod 4 / neverthrow / vitest / `@utils/dayjs`
+
+## Global Constraints
+
+- ツールは 5 つ: `list_logs` / `create_log` / `update_log` / `publish_log` / `delete_log`
+- `create_log` は必ず `_status: 'draft'` で作る。公開は `publish_log` のみ
+- `delete_log` は **`id` のみ**。title 照合は入れない(本人決定 2026-08-18)
+- `meta` の正準値は `src/collections/logs.ts` の `LOG_META_OPTIONS` ただ一つ。MCP 側にリテラルを複製しない
+- 日付は `YYYY-MM-DD` 固定。検証は `@utils/dayjs` の strict parse。生の `Date` / `Intl` / `slice` 禁止(`.claude/rules/dayjs-timezone.md`)
+- write path は strict。不正入力は**変換せず reject** し、①何が不正か ②有効な選択肢の全列挙 ③問題の値 ④回避手段 を含む回復ヒントを返す(`.claude/rules/mcp-write-strict.md`)
+- 関数は arrow function。`let` / IIFE / 非 null assertion `!` / `forEach` / `any` 禁止
+- `Boolean()` / `String()` / `Number()` 禁止。`parseInt(x, 10)` / テンプレートリテラル / 明示的な `!==` を使う
+- 各タスク完了時に `pnpm lint && pnpm typecheck` を通す。`npx tsc` は使わない
+- commit はタスク毎に行う。push と PR はしない
+
+---
+
+## 事前に確認済みの事実(推測ではない)
+
+| 事実                                                                                          | 出典                                 |
+| --------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `logs` に slug は無い。識別は `id` のみ                                                       | `src/collections/logs.ts`            |
+| `meta` の型は `'DJ' \| 'VJ' \| 'DJ/VJ' \| 'Support' \| 'Dev' \| 'Flyer' \| 'Talk' \| 'Video'` | `src/payload-types.ts:367`           |
+| `logs` は `versions: { drafts: { autosave: { interval: 375 } } }`                             | `src/collections/logs.ts`            |
+| `afterChange` / `afterDelete` が `/` と `/log` を revalidate 済み                             | `src/collections/logs.ts:10`         |
+| `publish_post` は **draft-promotion**(全フィールド再送)で実装されている                       | `src/lib/mcp/tools/index.ts:757-781` |
+| `PostNotFoundError` は `class X extends Error { override name = 'X' as const }` の形          | `src/lib/mcp/errors/index.ts:15`     |
+| `McpToolError` は union。新エラーは union にも足す                                            | `src/lib/mcp/errors/index.ts:95`     |
+
+## File Structure
+
+| ファイル                                           | 責務                                                    | タスク |
+| -------------------------------------------------- | ------------------------------------------------------- | ------ |
+| `src/collections/fields/log-meta/index.ts`         | **新規**。`LOG_META_OPTIONS` の葉モジュール             | 1      |
+| `src/collections/fields/log-meta/log-meta.test.ts` | **新規**。8 個のリテラル値を固定する                    | 1      |
+| `src/collections/logs.ts`                          | `options` を `LOG_META_OPTIONS` から導出する            | 1      |
+| `src/lib/mcp/errors/index.ts`                      | `LogNotFoundError` を追加し `McpToolError` union に足す | 2      |
+| `src/lib/mcp/tools/logs/index.ts`                  | **新規**。`createLogToolHandlers` + `registerLogTools`  | 2,3,4  |
+| `src/lib/mcp/tools/logs/logs.test.ts`              | **新規**。ハンドラの成功系と拒否系                      | 2,3,4  |
+| `src/app/api/mcp/route.ts`                         | `registerLogTools` を 1 行配線                          | 2      |
+
+---
+
+### Task 1: `meta` の正準値を葉モジュールに切り出す
+
+MCP 側にリテラルを複製せず、単一の出所を作る。
+
+**なぜ collection 本体から export しないか:** `src/collections/logs.ts` は
+`./hooks/revalidate` 経由で `next/cache` を先頭 import している。これを MCP ツールと
+node 環境の vitest に引き込むと壊れる。`src/collections/fields/slug/` が同じ用途の
+既存パターン(コロケートしたテスト付きの葉モジュール)なので、それに倣う。
+
+**同期テストは書かない:** collection の `options` を定数から `.map()` で**導出**すれば、
+構造上ドリフトが起こり得ない。`.claude/rules/cross-module-sync-test.md` が求めているのは
+本来これで、同期テストは「導出できない場合の次善策」。代わりにリテラル 8 個そのものを
+固定するテストを書く — `'DJ/VJ'` を `'DJ / VJ'` に直した瞬間に既存 DB 行とバイト不一致に
+なるが、`Log['meta']` も同時に再生成されるため型では守れない。
+
+**Files:**
+
+- Create: `src/collections/fields/log-meta/index.ts`
+- Create: `src/collections/fields/log-meta/log-meta.test.ts`
+- Modify: `src/collections/logs.ts`
+
+**Interfaces:**
+
+- Consumes: なし(最初のタスク)
+- Produces: `src/collections/fields/log-meta` から
+  `export const LOG_META_OPTIONS: readonly ['DJ','VJ','DJ/VJ','Support','Dev','Flyer','Talk','Video']`。
+  Task 3 の `z.enum(LOG_META_OPTIONS)` がこれを使う
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+Create `src/collections/fields/log-meta/log-meta.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { LOG_META_OPTIONS } from '.';
+
+// この 8 個の値は年表の表示ラベルそのものであり、既存の DB 行とバイト一致していないと
+// 壊れる。型(`Log['meta']`)は payload-types.ts の再生成で一緒に変わってしまうため、
+// 「うっかり表記を変えた」を型では検出できない。ここで値そのものに釘を刺す。
+describe('LOG_META_OPTIONS', () => {
+  it('既存の DB 行と一致する 8 個の値を保つ', () => {
+    expect([...LOG_META_OPTIONS]).toEqual(['DJ', 'VJ', 'DJ/VJ', 'Support', 'Dev', 'Flyer', 'Talk', 'Video']);
+  });
+
+  it('重複を含まない', () => {
+    expect(new Set(LOG_META_OPTIONS).size).toBe(LOG_META_OPTIONS.length);
+  });
+});
+```
+
+- [ ] **Step 2: 走らせて失敗を確認**
+
+Run: `pnpm exec vitest run src/collections/fields/log-meta/log-meta.test.ts`
+Expected: FAIL — モジュールが解決できない
+
+- [ ] **Step 3: 葉モジュールを作る**
+
+Create `src/collections/fields/log-meta/index.ts`:
+
+```ts
+import type { Log } from '@payload-types';
+
+// 年表に表示する種別ラベルの正準値。値がそのまま画面に出るため、既存行
+// (DJ / VJ / DJ/VJ)とバイト一致していなければならない。
+//
+// collection 本体(src/collections/logs.ts)ではなくここに置くのは、logs.ts が
+// ./hooks/revalidate 経由で next/cache を引いており、MCP ツール(src/lib/mcp/tools/logs)や
+// node 環境の vitest から import できないため。ここは依存ゼロの葉に保つこと。
+//
+// `satisfies readonly Log['meta'][]` により、payload-types.ts の再生成で union が
+// 変わった瞬間にコンパイルエラーになる。
+export const LOG_META_OPTIONS = ['DJ', 'VJ', 'DJ/VJ', 'Support', 'Dev', 'Flyer', 'Talk', 'Video'] as const satisfies readonly Log['meta'][];
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm exec vitest run src/collections/fields/log-meta/log-meta.test.ts`
+Expected: PASS(2 件)
+
+- [ ] **Step 5: collection の options を導出に差し替える**
+
+`src/collections/logs.ts` の import に足す(`./hooks/revalidate` の import の**前**):
+
+```ts
+import { LOG_META_OPTIONS } from './fields/log-meta';
+```
+
+`meta` フィールドの `options`(既存の 8 行のリテラル配列)を導出に差し替える:
+
+```ts
+      options: LOG_META_OPTIONS.map((value) => ({ label: value, value })),
+```
+
+既存の `// Stored verbatim and rendered as ...` コメントは**消さずに残す**。その下に 1 行足す:
+
+```ts
+      // 正準値は ./fields/log-meta。MCP の create_log / update_log も同じ配列から
+      // z.enum を組む。ここで導出しているのでリテラルの二重管理は発生しない。
+```
+
+- [ ] **Step 6: lint / typecheck / commit**
+
+Run:
+
+```bash
+pnpm exec vitest run src/collections/fields/log-meta/log-meta.test.ts
+pnpm lint && pnpm typecheck
+git add src/collections/fields/log-meta src/collections/logs.ts
+```
+
+commit message:
+
+```
+refactor(logs): extract LOG_META_OPTIONS as a dependency-free leaf module
+
+meta の値は年表の表示ラベルそのもので既存行とバイト一致が要る。MCP ツールが同じ
+選択肢を必要とするため単一の出所を作る。collection 本体は next/cache を引いていて
+MCP 側から import できないので、fields/slug と同じ葉モジュールの形にした。
+
+collection の options はこの配列から導出するため二重管理は発生しない。
+satisfies readonly Log['meta'][] で payload-types との drift をコンパイル時に検出し、
+リテラル 8 個そのものはテストで固定する(型では表記変更を検出できないため)。
+```
+
+---
+
+### Task 2: ツールの骨格と `list_logs`
+
+`LogToolDeps` / `registerLogTools` / `list_logs` を作り、`route.ts` まで配線して MCP に露出させる。
+
+**Files:**
+
+- Modify: `src/lib/mcp/errors/index.ts`
+- Create: `src/lib/mcp/tools/logs/index.ts`
+- Create: `src/lib/mcp/tools/logs/logs.test.ts`
+- Modify: `src/app/api/mcp/route.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1 の `LOG_META_OPTIONS`(このタスクではまだ使わない)
+- Produces:
+  - `export type LogToolDeps = { payload: Payload; user: User }`
+  - `export const createLogToolHandlers = (deps: LogToolDeps) => ({ listLogs, ... })`
+  - `export const registerLogTools = (server: McpServer, deps: LogToolDeps): void`
+  - `listLogs: (input: { status?: 'draft' | 'published' | 'all'; limit?: number }) => Promise<ToolResult>`
+  - `toSummary(doc: Log)` が返す形: `{ id, title, date, meta, url, status }`。`date` は JST 暦日の `YYYY-MM-DD`
+  - `export class LogNotFoundError extends Error`(`src/lib/mcp/errors`)
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+Create `src/lib/mcp/tools/logs/logs.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+
+import { createLogToolHandlers } from '.';
+
+import type { LogToolDeps } from '.';
+import type { User } from '@payload-types';
+
+const user = { id: 1, email: 'dev@napochaan.com' } as User;
+
+const createDeps = () => {
+  const payload = {
+    find: vi.fn(),
+    findByID: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  const deps = { payload, user } as unknown as LogToolDeps;
+
+  return { payload, deps };
+};
+
+describe('listLogs', () => {
+  it('published だけを引く where を組む', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({ docs: [] });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.listLogs({ status: 'published' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        draft: true,
+        where: { _status: { equals: 'published' } },
+        sort: '-date',
+        overrideAccess: false,
+        user,
+      }),
+    );
+  });
+
+  it('status 未指定なら all 扱いで where を付けない', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({ docs: [] });
+
+    const handlers = createLogToolHandlers(deps);
+    await handlers.listLogs({});
+
+    expect(payload.find).toHaveBeenCalledWith(expect.objectContaining({ where: undefined }));
+  });
+
+  it('date を JST 暦日の YYYY-MM-DD に正規化して返す', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({
+      docs: [{ id: 7, title: 'TBA at Real に VJ 出演', date: '2026-10-24T00:00:00.000Z', meta: 'VJ', url: null, _status: 'published' }],
+    });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.listLogs({});
+    const [{ text }] = result.content;
+
+    expect(JSON.parse(text)).toEqual([{ id: 7, title: 'TBA at Real に VJ 出演', date: '2026-10-24', meta: 'VJ', url: null, status: 'published' }]);
+  });
+});
+```
+
+- [ ] **Step 2: 走らせて失敗を確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: FAIL — `src/lib/mcp/tools/logs` が解決できない
+
+- [ ] **Step 3: エラー型を追加する**
+
+`src/lib/mcp/errors/index.ts` の `PostNotFoundError` の**直後**に足す:
+
+```ts
+// 指定 id の log(年表の手動エントリ)が見つからない。
+export class LogNotFoundError extends Error {
+  override name = 'LogNotFoundError' as const;
+}
+```
+
+`McpToolError` union に `LogNotFoundError` を足す(`PostNotFoundError` の次の行):
+
+```ts
+  | LogNotFoundError
+```
+
+- [ ] **Step 4: 骨格と `list_logs` を実装する**
+
+Create `src/lib/mcp/tools/logs/index.ts`:
+
+```ts
+import { fromPromise } from 'neverthrow';
+import { z } from 'zod';
+
+import { dayjs } from '@utils/dayjs';
+
+import { PayloadOperationError } from '../../errors';
+import { ok, toToolError } from '../shared/tool-result';
+
+import type { ToolResult } from '../shared/tool-result';
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { Log, User } from '@payload-types';
+import type { Payload } from 'payload';
+import type { Where } from 'payload';
+
+// logs は richText を持たないフラットな collection なので、blog/legal が必要とする
+// MarkdownCodec は渡さない。deps は payload と user だけ。
+export type LogToolDeps = {
+  payload: Payload;
+  user: User;
+};
+
+type LogStatus = 'draft' | 'published' | 'all';
+
+// Payload の date フィールドは ISO タイムスタンプで返る。read は write が受け付ける
+// 正準形(YYYY-MM-DD)に正規化する — でないと list → update の往復で date を素直に
+// 渡し戻したときに弾かれる(read-normalize / write-strict)。
+// dayOnly の値は UTC インスタントなので、JST 暦日で切らないと 1 日ズレる
+// (.claude/rules/dayjs-timezone.md)。
+const toSummary = (doc: Log) => ({
+  id: doc.id,
+  title: doc.title,
+  date: dayjs(doc.date).tz('Asia/Tokyo').format('YYYY-MM-DD'),
+  meta: doc.meta,
+  url: doc.url ?? null,
+  status: doc._status ?? 'draft',
+});
+
+const resolveStatusWhere = (status: LogStatus): Where | undefined => {
+  switch (status) {
+    case 'all':
+      return undefined;
+    case 'draft':
+      return { _status: { equals: 'draft' } };
+    case 'published':
+      return { _status: { equals: 'published' } };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`unhandled log status: ${`${_exhaustive}`}`);
+    }
+  }
+};
+
+export const createLogToolHandlers = (deps: LogToolDeps) => {
+  const { payload, user } = deps;
+
+  return {
+    listLogs: (input: { status?: LogStatus; limit?: number }): Promise<ToolResult> =>
+      fromPromise(
+        payload.find({
+          collection: 'logs',
+          draft: true,
+          where: resolveStatusWhere(input.status ?? 'all'),
+          limit: input.limit ?? 0,
+          sort: '-date',
+          overrideAccess: false,
+          user,
+          depth: 0,
+        }),
+        (cause) => new PayloadOperationError('log 一覧の取得に失敗しました', { cause }),
+      )
+        .map(({ docs }) => docs.map(toSummary))
+        .match(ok, toToolError),
+  };
+};
+
+export const registerLogTools = (server: McpServer, deps: LogToolDeps): void => {
+  const handlers = createLogToolHandlers(deps);
+
+  server.registerTool(
+    'list_logs',
+    {
+      title: 'log 一覧',
+      description: '/log の年表に載る手動エントリを一覧する。id / title / date / meta / url / 公開状態を返す。update_log・publish_log・delete_log に渡す id はここで確認する。',
+      inputSchema: {
+        status: z.enum(['draft', 'published', 'all']).optional().describe('既定は all'),
+        limit: z.number().int().positive().optional().describe('既定は無制限'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    handlers.listLogs,
+  );
+};
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: PASS(3 件)
+
+- [ ] **Step 6: route.ts に配線する**
+
+`src/app/api/mcp/route.ts` の import に足す(`registerLegalTools` の import の次の行):
+
+```ts
+import { registerLogTools } from '@lib/mcp/tools/logs';
+```
+
+`registerLegalTools(...)` の呼び出しの**直後**に足す:
+
+```ts
+  // logs は richText を持たないので codec は渡さない。
+  registerLogTools(server, { payload, user });
+```
+
+- [ ] **Step 7: 全テスト + lint + typecheck + commit**
+
+Run:
+
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+git add src/lib/mcp/errors/index.ts src/lib/mcp/tools/logs src/app/api/mcp/route.ts
+```
+
+commit message:
+
+```
+feat(mcp): add list_logs and wire the logs tool module
+
+logs は richText を持たないため MarkdownCodec を渡さず、deps は payload/user のみ。
+date は Payload が ISO で返すので、write が受け付ける YYYY-MM-DD に JST 暦日で
+正規化して返す(read-normalize / write-strict)。
+```
+
+---
+
+### Task 3: `create_log` と `update_log`
+
+write path。`meta` は Task 1 の正準値から `z.enum` を組み、`date` は strict parse で検証する。
+
+**Files:**
+
+- Modify: `src/lib/mcp/tools/logs/index.ts`
+- Modify: `src/lib/mcp/tools/logs/logs.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 1 の `LOG_META_OPTIONS`、Task 2 の `createLogToolHandlers` / `toSummary` / `LogNotFoundError`
+- Produces:
+  - `createLog: (input: { title: string; date: string; meta: Log['meta']; url?: string }) => Promise<ToolResult>`
+  - `updateLog: (input: { id: number; title?: string; date?: string; meta?: Log['meta']; url?: string }) => Promise<ToolResult>`
+  - `findLog(id: number): ResultAsync<Log | null, McpToolError>` と `requireLog(doc: Log | null): ResultAsync<Log, McpToolError>` を module 内に用意する。Task 4 の `publish_log` / `delete_log` が再利用する
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+`src/lib/mcp/tools/logs/logs.test.ts` の末尾に足す:
+
+```ts
+describe('createLog', () => {
+  it('draft として作成する', async () => {
+    const { payload, deps } = createDeps();
+    payload.create.mockResolvedValue({ id: 9, title: 'Booth2Booth vol.04', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'Booth2Booth vol.04', date: '2026-11-01', meta: 'DJ/VJ' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        draft: true,
+        overrideAccess: false,
+        user,
+        data: expect.objectContaining({ title: 'Booth2Booth vol.04', date: '2026-11-01', meta: 'DJ/VJ', _status: 'draft' }),
+      }),
+    );
+  });
+
+  it('date の形式が違えば回復ヒント付きで reject し、create しない', async () => {
+    const { payload, deps } = createDeps();
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'x', date: '2026/11/01', meta: 'DJ' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('YYYY-MM-DD');
+    expect(result.content[0].text).toContain('2026/11/01');
+    expect(payload.create).not.toHaveBeenCalled();
+  });
+
+  it('存在しない日付は reject する', async () => {
+    const { payload, deps } = createDeps();
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'x', date: '2026-02-30', meta: 'DJ' });
+
+    expect(result.isError).toBe(true);
+    expect(payload.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateLog', () => {
+  it('指定したフィールドだけを渡す', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '旧', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+    payload.update.mockResolvedValue({ id: 9, title: '新', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 9, title: '新' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, data: { title: '新' } }));
+  });
+
+  it('存在しない id は回復ヒント付きで reject し、update しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 999, title: '新' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('list_logs');
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 走らせて失敗を確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: FAIL — `handlers.createLog is not a function`
+
+- [ ] **Step 3: date validator と findLog/requireLog を足す**
+
+`src/lib/mcp/tools/logs/index.ts` の import を差し替える:
+
+```ts
+import { err as errResult, errAsync, fromPromise, ok as okResult, okAsync } from 'neverthrow';
+import { z } from 'zod';
+
+import { dayjs } from '@utils/dayjs';
+import { createValidator } from '@utils/run-validators';
+
+// collection 本体(src/collections/logs.ts)は next/cache を引くのでここからは import
+// できない。正準値は依存ゼロの葉モジュールに置いてある(Task 1)。
+// src/collections に path alias は無く、tsconfig の paths 変更は禁止(CLAUDE.md)なので相対。
+import { LOG_META_OPTIONS } from '../../../../collections/fields/log-meta';
+import { InvalidInputError, LogNotFoundError, PayloadOperationError } from '../../errors';
+import { ok, toToolError } from '../shared/tool-result';
+
+import type { McpToolError } from '../../errors';
+import type { ToolResult } from '../shared/tool-result';
+import type { Validator } from '@utils/run-validators';
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { Log, User } from '@payload-types';
+import type { ResultAsync } from 'neverthrow';
+import type { Payload, Where } from 'payload';
+```
+
+`toSummary` の**上**に日付検証を置く(legal の `parseEffectiveAt` と同じ構成):
+
+```ts
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// 1. 形式 — YYYY-MM-DD かどうか。
+const requireDayFormat: Validator<string, McpToolError> = {
+  run: (value) => (DAY_PATTERN.test(value) ? okResult(value) : errResult(new InvalidInputError(`date は YYYY-MM-DD 形式で指定してください。受け取った値: "${value}"`))),
+};
+
+// 2. 実在 — 2026-02-30 のような「形式は合うが存在しない日付」を弾く。dayjs の strict parse
+//    (customParseFormat)はロールオーバーせず invalid として検出する。
+const requireRealDay: Validator<string, McpToolError> = {
+  run: (value) => (dayjs(value, 'YYYY-MM-DD', true).isValid() ? okResult(value) : errResult(new InvalidInputError(`date が存在しない日付です。受け取った値: "${value}"`))),
+};
+
+const validateDate = createValidator([requireDayFormat, requireRealDay]);
+
+const parseDate = (value: string): ResultAsync<string, McpToolError> => validateDate(value).asyncAndThen((valid) => okAsync(valid));
+```
+
+`createLogToolHandlers` の中、`return {` の**前**に共有ヘルパを置く:
+
+```ts
+  const findLog = (id: number): ResultAsync<Log | null, McpToolError> =>
+    fromPromise(
+      payload.findByID({ collection: 'logs', id, draft: true, disableErrors: true, overrideAccess: false, user, depth: 0 }),
+      (cause) => new PayloadOperationError('log の取得に失敗しました', { cause }),
+    );
+
+  const requireLog = (doc: Log | null): ResultAsync<Log, McpToolError> =>
+    doc === null ? errAsync(new LogNotFoundError('log が見つかりません。list_logs で id を確認してください。')) : okAsync(doc);
+```
+
+- [ ] **Step 4: `createLog` と `updateLog` を実装する**
+
+`listLogs` の**次**にハンドラを足す:
+
+```ts
+    createLog: (input: { title: string; date: string; meta: Log['meta']; url?: string }): Promise<ToolResult> =>
+      parseDate(input.date)
+        .andThen(() =>
+          fromPromise(
+            payload.create({
+              collection: 'logs',
+              draft: true,
+              data: { title: input.title, date: input.date, meta: input.meta, url: input.url },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の作成に失敗しました', { cause }),
+          ),
+        )
+        .map((created) => ({ ...toSummary(created), note: 'draft として作成した。年表に載せるには publish_log を呼ぶこと。' }))
+        .match(ok, toToolError),
+
+    updateLog: (input: { id: number; title?: string; date?: string; meta?: Log['meta']; url?: string }): Promise<ToolResult> =>
+      // date が来ていれば先に検証する。未指定なら検証をスキップして素通しする。
+      (input.date === undefined ? okAsync<string | undefined, McpToolError>(undefined) : parseDate(input.date))
+        .andThen(() => findLog(input.id))
+        .andThen(requireLog)
+        .andThen(() =>
+          fromPromise(
+            payload.update({
+              collection: 'logs',
+              id: input.id,
+              draft: true,
+              // 指定されたフィールドだけを送る。undefined を混ぜると Payload 側で
+              // 既存値を上書きしうるため、キー自体を落とす。
+              data: {
+                ...(input.title === undefined ? {} : { title: input.title }),
+                ...(input.date === undefined ? {} : { date: input.date }),
+                ...(input.meta === undefined ? {} : { meta: input.meta }),
+                ...(input.url === undefined ? {} : { url: input.url }),
+              },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の更新に失敗しました', { cause }),
+          ),
+        )
+        .map((updated) => ({ ...toSummary(updated), note: 'draft を更新した。年表への反映は publish_log を呼ぶこと。' }))
+        .match(ok, toToolError),
+```
+
+- [ ] **Step 5: ツール登録を足す**
+
+`registerLogTools` の中、`list_logs` の登録の**次**に足す:
+
+```ts
+  server.registerTool(
+    'create_log',
+    {
+      title: 'log 作成(draft)',
+      description: '年表の手動エントリを draft として作成する。年表に載せるには publish_log を続けて呼ぶこと。',
+      inputSchema: {
+        title: z.string().min(1).describe('年表に出るテキスト。例: "Booth2Booth vol.03 at VRChat 開催"'),
+        date: z.string().describe('YYYY-MM-DD'),
+        meta: z.enum(LOG_META_OPTIONS).describe('年表に出る種別ラベル。この値がそのまま画面に表示される'),
+        url: z.string().url().optional().describe('設定するとタイトルがこの URL へのリンクになる'),
+      },
+      annotations: { destructiveHint: false },
+    },
+    handlers.createLog,
+  );
+
+  server.registerTool(
+    'update_log',
+    {
+      title: 'log 更新(draft)',
+      description: 'log を更新する。指定したフィールドだけが変わる。年表への反映は publish_log を呼ぶこと。',
+      inputSchema: {
+        id: z.number().int(),
+        title: z.string().min(1).optional(),
+        date: z.string().optional().describe('YYYY-MM-DD'),
+        meta: z.enum(LOG_META_OPTIONS).optional(),
+        url: z.string().url().optional(),
+      },
+      annotations: { destructiveHint: false },
+    },
+    handlers.updateLog,
+  );
+```
+
+- [ ] **Step 6: テストが通ることを確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: PASS(8 件)
+
+- [ ] **Step 7: 全テスト + lint + typecheck + commit**
+
+Run:
+
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+git add src/lib/mcp/tools/logs
+```
+
+commit message:
+
+```
+feat(mcp): add create_log and update_log
+
+meta は collection の LOG_META_OPTIONS から z.enum を組み、リテラルを複製しない。
+date は形式と実在の 2 段で strict 検証する(2026-02-30 のような存在しない日付を
+dayjs の strict parse で弾く)。update は指定されたキーだけを送る。
+```
+
+---
+
+### Task 4: `publish_log` と `delete_log`
+
+**Files:**
+
+- Modify: `src/lib/mcp/tools/logs/index.ts`
+- Modify: `src/lib/mcp/tools/logs/logs.test.ts`
+
+**Interfaces:**
+
+- Consumes: Task 3 の `findLog` / `requireLog` / `toSummary`
+- Produces:
+  - `publishLog: (input: { id: number }) => Promise<ToolResult>`
+  - `deleteLog: (input: { id: number }) => Promise<ToolResult>`
+
+- [ ] **Step 1: 失敗するテストを追記する**
+
+`src/lib/mcp/tools/logs/logs.test.ts` の末尾に足す:
+
+```ts
+describe('publishLog', () => {
+  // draft-promotion: versions.drafts が有効なため update_log の変更は versions テーブルに
+  // 積まれる。bare `_status` だけを update すると published 済みの main テーブル行の上に
+  // 浅くマージされ、未公開の draft 編集が黙って失われる(blog の publishPost と同じ罠)。
+  it('最新 draft の全フィールドを published で再送する', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'draft' });
+    payload.update.mockResolvedValue({ id: 9, title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'published' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.publishLog({ id: 9 });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        id: 9,
+        data: { title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'published' },
+      }),
+    );
+  });
+
+  it('存在しない id は reject し、update しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.publishLog({ id: 999 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('list_logs');
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteLog', () => {
+  it('存在する id を削除する', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '消す対象', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+    payload.delete.mockResolvedValue({ id: 9 });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.deleteLog({ id: 9 });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.delete).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, overrideAccess: false, user }));
+    expect(JSON.parse(result.content[0].text)).toEqual(expect.objectContaining({ id: 9, title: '消す対象' }));
+  });
+
+  it('存在しない id は回復ヒント付きで reject し、delete しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.deleteLog({ id: 999 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('list_logs');
+    expect(payload.delete).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 走らせて失敗を確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: FAIL — `handlers.publishLog is not a function`
+
+- [ ] **Step 3: ハンドラを実装する**
+
+`updateLog` の**次**に足す:
+
+```ts
+    publishLog: (input: { id: number }): Promise<ToolResult> =>
+      findLog(input.id)
+        .andThen(requireLog)
+        // draft-promotion: versions.drafts が有効なため update_log の変更は versions
+        // テーブルに積まれる。ここで bare `_status` だけを update すると published 済みの
+        // main テーブル行の上に浅くマージされ、未公開の draft 編集が黙って失われる。
+        // 最新 draft を読み直し、全フィールドを published 付きで再送する
+        // (blog の publishPost と同じ形、src/lib/mcp/tools/index.ts)。
+        .andThen((current) =>
+          fromPromise(
+            payload.update({
+              collection: 'logs',
+              id: input.id,
+              data: {
+                title: current.title,
+                date: current.date,
+                meta: current.meta,
+                url: current.url,
+                _status: 'published',
+              },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の公開に失敗しました', { cause }),
+          ),
+        )
+        .map((published) => ({ ...toSummary(published), note: '公開した。/log の年表に反映される。' }))
+        .match(ok, toToolError),
+
+    deleteLog: (input: { id: number }): Promise<ToolResult> =>
+      // 削除前に実物を引くのは ①存在しない id を回復ヒントで弾く ②何を消したかを
+      // 応答に含める、の 2 つのため。Payload の delete はバージョンごと消すハード削除で
+      // 復元手段がない。
+      findLog(input.id)
+        .andThen(requireLog)
+        .andThen((doc) =>
+          fromPromise(
+            payload.delete({ collection: 'logs', id: input.id, overrideAccess: false, user }),
+            (cause) => new PayloadOperationError('log の削除に失敗しました', { cause }),
+          ).map(() => doc),
+        )
+        .map((deleted) => ({ ...toSummary(deleted), note: '削除した。復元はできない。' }))
+        .match(ok, toToolError),
+```
+
+- [ ] **Step 4: ツール登録を足す**
+
+`registerLogTools` の中、`update_log` の登録の**次**に足す:
+
+```ts
+  server.registerTool(
+    'publish_log',
+    {
+      title: 'log 公開',
+      description: 'log を公開して /log の年表に載せる。最新 draft の内容がそのまま公開される。',
+      inputSchema: { id: z.number().int() },
+      annotations: { destructiveHint: false },
+    },
+    handlers.publishLog,
+  );
+
+  server.registerTool(
+    'delete_log',
+    {
+      title: 'log 削除',
+      description: 'log を削除する。復元はできない。削除前に list_logs で対象の id を必ず確認すること。',
+      inputSchema: { id: z.number().int() },
+      annotations: { destructiveHint: true },
+    },
+    handlers.deleteLog,
+  );
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `pnpm exec vitest run src/lib/mcp/tools/logs/logs.test.ts`
+Expected: PASS(12 件)
+
+- [ ] **Step 6: 全テスト + lint + typecheck + commit**
+
+Run:
+
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+git add src/lib/mcp/tools/logs
+```
+
+commit message:
+
+```
+feat(mcp): add publish_log and delete_log
+
+publish_log は blog の publishPost と同じ draft-promotion。bare _status 更新だと
+published 行に浅くマージされて未公開の draft 編集が消えるため、最新 draft を
+読み直して全フィールドを再送する。
+
+delete_log は id のみで照合ガードは持たない(設計判断、spec に記録)。
+ハード削除で復元手段がないため destructiveHint: true を付ける。
+```
+
+---
+
+### Task 5: 全体検証とレビュー依頼
+
+**Files:**
+
+- Modify: なし(想定)
+
+**Interfaces:**
+
+- Consumes: Task 1-4 の全変更
+- Produces: レビュー可能な差分
+
+- [ ] **Step 1: ツールが 5 つ登録されていることを確認**
+
+Run:
+
+```bash
+grep -c "server.registerTool(" src/lib/mcp/tools/logs/index.ts
+```
+
+Expected: `5`
+
+- [ ] **Step 2: meta のリテラルが複製されていないことを確認**
+
+Run:
+
+```bash
+grep -rn "DJ/VJ" src/lib src/app src/collections
+```
+
+Expected: `src/collections/fields/log-meta/index.ts` と同ディレクトリの
+`log-meta.test.ts` の 2 ファイルのみ。`src/lib` / `src/app` / `src/collections/logs.ts` に
+出たら複製が残っている
+
+- [ ] **Step 3: 全体検証**
+
+Run:
+
+```bash
+pnpm test && pnpm lint && pnpm typecheck
+```
+
+Expected: すべて PASS
+
+- [ ] **Step 4: 本番相当ビルド**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: 成功
+
+- [ ] **Step 5: difit でレビュー依頼**
+
+Run:
+
+```bash
+nohup difit HEAD origin/main --merge-base --no-open --keep-alive --port 4982 > /dev/null 2>&1 &
+```
+
+差分を提示してレビューを依頼する。push と PR は承認後に行う。
+
+---
+
+## 本計画の範囲外
+
+- **staging E2E**: 実装完了後に別途判断する。手順は memory の `staging-mcp-e2e-via-cloudflared`。
+- **`unpublish_log`**: 「年表から下ろす」操作は入れない(YAGNI)。必要になったら追加する。
+- **年表の派生エントリ**(news / works / 外部投稿から導出される項目)は `logs` collection の管轄外。

--- a/docs/superpowers/specs/2026-08-18-logs-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-08-18-logs-mcp-tools-design.md
@@ -57,8 +57,19 @@ export const LOG_META_OPTIONS = [
 `satisfies readonly Log['meta'][]` により、`payload-types.ts` の再生成で union が
 変わった瞬間にコンパイルエラーになる。MCP 側は `z.enum(LOG_META_OPTIONS)`。
 
-`.claude/rules/cross-module-sync-test.md` の方針に従い、collection の `options` と
-`LOG_META_OPTIONS` の一致をテストで表明し、同ルールの「Known Sync Pairs」表にも追記する。
+collection 側の `options` は `LOG_META_OPTIONS.map((value) => ({ label: value, value }))`
+で**この配列から導出する**(`.claude/rules/cross-module-sync-test.md` が言う「2 つの
+値をハンドで同期し続ける」状況にそもそもならない)。そのため同ルールが求める
+「両方を import して 1:1 を assert するクロスモジュールテスト」は不要と判断し、
+追加しなかった。ソースが 1 つしかない以上、drift は構造的に起こり得ない。
+
+代わりに `src/collections/fields/log-meta/log-meta.test.ts` の colocated テストが
+`LOG_META_OPTIONS` の 8 個の値そのものを固定する。型(`Log['meta']`)は
+`payload-types.ts` の再生成で一緒に変わってしまうため「うっかり表記を変えた」を
+型では検出できない — 例えば `'DJ/VJ'` を `'DJ / VJ'` のように書き換えても
+`satisfies readonly Log['meta'][]` は通ってしまう。この値は既存 DB 行の `meta`
+カラムとバイト一致していないと年表の表示が壊れるため、リテラルを直接ピン留めする
+必要がある。
 
 ### `delete_log` は `id` のみ(title 照合なし)
 
@@ -97,10 +108,10 @@ src/lib/mcp/tools/logs/
 └── logs.test.ts
 ```
 
-- `src/collections/logs.ts` — `LOG_META_OPTIONS` を export し、`options` をそこから組む
+- `src/collections/fields/log-meta` — `LOG_META_OPTIONS` を export する依存ゼロの葉モジュール
+- `src/collections/logs.ts` — `LOG_META_OPTIONS.map(...)` から `options` を組む(import のみ)
 - `src/app/api/mcp/route.ts` — `registerLogTools(server, { payload, user })` を 1 行追加。
   **codec は渡さない**(richText なし)
-- `.claude/rules/cross-module-sync-test.md` — Known Sync Pairs 表に 1 行追記
 
 `LogToolDeps` は `{ payload: Payload; user: User }` のみ。blog の `BlogToolDeps` が持つ
 `codec` / `signingSecret` / `siteBaseUrl` はいずれも不要。
@@ -135,10 +146,11 @@ src/lib/mcp/tools/logs/
 - `date` の不正形式(`2026/10/24`, `10-24`, 実在しない `2026-02-30`)
 - 存在しない `id`(`update_log` / `publish_log` / `delete_log` すべて)
 
-同期テスト:
+同期は保証しない、値は固定する:
 
-- `LOG_META_OPTIONS` と collection の `options` の `value` 列が 1:1 で一致すること
-  (両方を import して assert する — 片側のハードコードでは drift を検出できない)
+- collection の `options` は `LOG_META_OPTIONS` から `.map()` で導出するため、両者の
+  同期を assert するテストは不要(上の「決定事項と根拠」参照)
+- 代わりに `log-meta.test.ts` が `LOG_META_OPTIONS` の 8 個の値そのものをピン留めする
 
 ## 範囲外
 

--- a/docs/superpowers/specs/2026-08-18-logs-mcp-tools-design.md
+++ b/docs/superpowers/specs/2026-08-18-logs-mcp-tools-design.md
@@ -1,0 +1,149 @@
+# logs collection の MCP ツール 設計
+
+- 日付: 2026-08-18
+- 対象: `src/lib/mcp/tools/logs/`(新規), `src/collections/logs.ts`, `src/app/api/mcp/route.ts`
+- 目的: `/log` の年表に載る手動エントリ(`logs` collection)を MCP から追加・編集・公開・削除できるようにする
+
+## 背景
+
+`logs` は既存の MCP 対象 2 コレクションとかなり性格が違う。
+
+|               | blog                | legal          | **logs**                              |
+| ------------- | ------------------- | -------------- | ------------------------------------- |
+| slug          | あり                | あり           | **なし**(識別は `id` のみ)            |
+| richText 本文 | あり                | あり           | **なし**(4 フィールド)                |
+| MCP から公開  | `publish_post` あり | 不可(admin UI) | **`publish_log` を作る**              |
+| 削除ツール    | なし                | なし           | **`delete_log` を作る(リポジトリ初)** |
+
+richText を持たないため、blog/legal が必要としている Markdown codec 層
+(image-ref パーサ、block フェンス検証、署名付きアップロード)は**丸ごと不要**。
+`legal` ツールが最も近い雛形になる。
+
+`/log` の年表は `_status: 'published'` のものだけを表示する(`src/lib/payload/logs/index.ts`)。
+draft で作った log は年表に出ない。
+
+## ツール構成(5 つ)
+
+| ツール        | 引数                                               | 用途                                                  |
+| ------------- | -------------------------------------------------- | ----------------------------------------------------- |
+| `list_logs`   | `status?`(`draft` / `published` / `all`), `limit?` | id を得る唯一の手段。update / publish / delete の前提 |
+| `create_log`  | `title`, `date`, `meta`, `url?`                    | **draft** で作成                                      |
+| `update_log`  | `id` + 変更したいフィールドのみ                    | 指定したフィールドだけ変わる                          |
+| `publish_log` | `id`                                               | 年表に載せる                                          |
+| `delete_log`  | `id`                                               | ハード削除                                            |
+
+`create_log` が draft を作り `publish_log` で公開する 2 段階は blog と同じ形
+(本人決定 2026-08-18)。log は 4 フィールドの事実データだが、公開の意思決定を
+明示的な操作として残す。
+
+## 決定事項と根拠
+
+### `meta` を単一ソース化する
+
+`meta` の値は**そのまま年表の表示ラベルになる**うえ、既存行が `DJ` などと
+バイト一致していないと壊れる(`src/collections/logs.ts` のコメントに明記済み)。
+
+現状はリテラルが collection 定義の中に埋まっていて外から参照できない。MCP 側に
+同じリテラルを書くと、片方だけ増えたときに気づけない。そこで collection から export し、
+collection 自身の `options` もその配列から組む。
+
+```ts
+// src/collections/logs.ts
+export const LOG_META_OPTIONS = [
+  'DJ', 'VJ', 'DJ/VJ', 'Support', 'Dev', 'Flyer', 'Talk', 'Video',
+] as const satisfies readonly Log['meta'][];
+```
+
+`satisfies readonly Log['meta'][]` により、`payload-types.ts` の再生成で union が
+変わった瞬間にコンパイルエラーになる。MCP 側は `z.enum(LOG_META_OPTIONS)`。
+
+`.claude/rules/cross-module-sync-test.md` の方針に従い、collection の `options` と
+`LOG_META_OPTIONS` の一致をテストで表明し、同ルールの「Known Sync Pairs」表にも追記する。
+
+### `delete_log` は `id` のみ(title 照合なし)
+
+**本人決定 2026-08-18。** 当初は誤爆防止に `title` の完全一致を必須にする案を提示したが、
+`id` だけで弾く形が選ばれた。
+
+- 存在しない `id` → 回復ヒント付きで reject
+  (「id=N の log は見つかりません。list_logs で id を確認してください。」)
+- 存在する `id` → `payload.delete()` でハード削除
+
+**受容したトレードオフ**: LLM が「存在するが別の」 id を掴んだ場合、サーバー側で止める
+手段はない。残る抑止は `annotations: { destructiveHint: true }` によるクライアント側の
+確認 UI のみで、これを尊重するかはクライアント実装に依存する。Payload の `delete()` は
+バージョンテーブルごと消すハード削除で復元手段はない。
+
+### 日付は必ず `@utils/dayjs` を通す
+
+`date` は `dayOnly` の date フィールド。**dayOnly は UTC インスタントで返るため、
+JST で素朴に slice すると 1 日ズレる** — legal の `effectiveAt` で実際に起きた事故
+(`.claude/rules` 外だが memory に記録あり)。
+
+MCP は `YYYY-MM-DD` 固定で受け、`@utils/dayjs` の strict parse(`customParseFormat`)で
+検証する。生の `Date` / `Intl` / `slice` は使わない(`.claude/rules/dayjs-timezone.md`)。
+
+### ISR は追加実装しない
+
+`src/collections/logs.ts` の `afterChange` / `afterDelete` フックが既に `/` と `/log` を
+revalidate する(`createPublishedTagAndPathRevalidateHooks([CACHE_TAGS.logs], ['/', '/log'])`)。
+delete もフック経由で自動反映されるため、MCP 側に revalidation の実装は不要。
+
+## ファイル構成
+
+```
+src/lib/mcp/tools/logs/
+├── index.ts        # createLogToolHandlers + registerLogTools
+└── logs.test.ts
+```
+
+- `src/collections/logs.ts` — `LOG_META_OPTIONS` を export し、`options` をそこから組む
+- `src/app/api/mcp/route.ts` — `registerLogTools(server, { payload, user })` を 1 行追加。
+  **codec は渡さない**(richText なし)
+- `.claude/rules/cross-module-sync-test.md` — Known Sync Pairs 表に 1 行追記
+
+`LogToolDeps` は `{ payload: Payload; user: User }` のみ。blog の `BlogToolDeps` が持つ
+`codec` / `signingSecret` / `siteBaseUrl` はいずれも不要。
+
+## エラー処理
+
+既存の `src/lib/mcp/tools/shared/tool-result`(`ok` / `toToolError`)と
+`src/lib/mcp/errors` に乗せる。neverthrow の `ResultAsync` チェーンで組み、
+`.match(ok, toToolError)` で終端する(`legal/index.ts` と同じ形)。
+
+新規に要るエラーは「log が見つからない」のみ。既存の `PostNotFoundError` と同型の
+`LogNotFoundError` を `errors` に追加する。
+
+回復ヒントは `.claude/rules/mcp-write-strict.md` に従い、①何が不正か ②有効な選択肢の
+全列挙 ③問題の値 ④回避手段、を含める。特に `meta` の不正値は 8 個の選択肢を全部出す。
+
+## テスト
+
+`logs.test.ts` で payload をモックし、**拒否系を厚く**する。
+
+成功系:
+
+- `list_logs` が status filter ごとに正しい `where` を組む
+- `create_log` が `_status: 'draft'` で作る
+- `update_log` が指定フィールドだけを渡す
+- `publish_log` が `_status: 'published'` にする
+- `delete_log` が `payload.delete()` を呼ぶ
+
+拒否系:
+
+- `meta` の不正値 → 8 択を列挙した回復ヒント
+- `date` の不正形式(`2026/10/24`, `10-24`, 実在しない `2026-02-30`)
+- 存在しない `id`(`update_log` / `publish_log` / `delete_log` すべて)
+
+同期テスト:
+
+- `LOG_META_OPTIONS` と collection の `options` の `value` 列が 1:1 で一致すること
+  (両方を import して assert する — 片側のハードコードでは drift を検出できない)
+
+## 範囲外
+
+- **年表の派生エントリ**(news / works / 外部投稿から導出される項目)は `logs` collection の
+  管轄外。本設計は手動エントリのみを扱う。
+- **`unpublish_log`**: 「年表から下ろす」操作は今回入れない。必要になったら追加する(YAGNI)。
+- **staging E2E**: 実装完了後に別途判断する。手順は memory の
+  `staging-mcp-e2e-via-cloudflared` にある。

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -7,6 +7,7 @@ import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/valida
 import { createMarkdownCodec } from '@lib/mcp/markdown';
 import { registerBlogTools } from '@lib/mcp/tools';
 import { registerLegalTools } from '@lib/mcp/tools/legal';
+import { registerLogTools } from '@lib/mcp/tools/logs';
 import { blogEditorFeatures } from '@lib/payload/editor-features';
 import { getPayloadClient } from '@lib/payload/client';
 
@@ -79,6 +80,8 @@ const handleMCPRequest = async (request: Request): Promise<Response> => {
     siteBaseUrl: process.env.BASE_URL ?? 'http://localhost:3000',
   });
   registerLegalTools(server, { payload, user, codec: createMarkdownCodec<LegalDocument['body']>(editorConfig) });
+  // logs は richText を持たないので codec は渡さない。
+  registerLogTools(server, { payload, user });
 
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined, // stateless モード

--- a/src/collections/fields/log-meta/index.ts
+++ b/src/collections/fields/log-meta/index.ts
@@ -1,0 +1,12 @@
+import type { Log } from '@payload-types';
+
+// 年表に表示する種別ラベルの正準値。値がそのまま画面に出るため、既存行
+// (DJ / VJ / DJ/VJ)とバイト一致していなければならない。
+//
+// collection 本体(src/collections/logs.ts)ではなくここに置くのは、logs.ts が
+// ./hooks/revalidate 経由で next/cache を引いており、MCP ツール(src/lib/mcp/tools/logs)や
+// node 環境の vitest から import できないため。ここは依存ゼロの葉に保つこと。
+//
+// `satisfies readonly Log['meta'][]` により、payload-types.ts の再生成で union が
+// 変わった瞬間にコンパイルエラーになる。
+export const LOG_META_OPTIONS = ['DJ', 'VJ', 'DJ/VJ', 'Support', 'Dev', 'Flyer', 'Talk', 'Video'] as const satisfies readonly Log['meta'][];

--- a/src/collections/fields/log-meta/log-meta.test.ts
+++ b/src/collections/fields/log-meta/log-meta.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { LOG_META_OPTIONS } from '.';
+
+// この 8 個の値は年表の表示ラベルそのものであり、既存の DB 行とバイト一致していないと
+// 壊れる。型(`Log['meta']`)は payload-types.ts の再生成で一緒に変わってしまうため、
+// 「うっかり表記を変えた」を型では検出できない。ここで値そのものに釘を刺す。
+describe('LOG_META_OPTIONS', () => {
+  it('既存の DB 行と一致する 8 個の値を保つ', () => {
+    expect([...LOG_META_OPTIONS]).toEqual(['DJ', 'VJ', 'DJ/VJ', 'Support', 'Dev', 'Flyer', 'Talk', 'Video']);
+  });
+
+  it('重複を含まない', () => {
+    expect(new Set(LOG_META_OPTIONS).size).toBe(LOG_META_OPTIONS.length);
+  });
+});

--- a/src/collections/logs.ts
+++ b/src/collections/logs.ts
@@ -1,5 +1,6 @@
 import { CACHE_TAGS } from '@utils/cache-tags';
 
+import { LOG_META_OPTIONS } from './fields/log-meta';
 import { createPublishedTagAndPathRevalidateHooks } from './hooks/revalidate';
 
 import type { CollectionConfig } from 'payload';
@@ -46,16 +47,9 @@ export const Logs = {
       // Stored verbatim and rendered as the timeline's type label, so each
       // `value` IS the on-screen text. Existing rows hold DJ / VJ / DJ/VJ, so
       // those values must stay byte-identical; the rest are new roles.
-      options: [
-        { label: 'DJ', value: 'DJ' },
-        { label: 'VJ', value: 'VJ' },
-        { label: 'DJ/VJ', value: 'DJ/VJ' },
-        { label: 'Support', value: 'Support' },
-        { label: 'Dev', value: 'Dev' },
-        { label: 'Flyer', value: 'Flyer' },
-        { label: 'Talk', value: 'Talk' },
-        { label: 'Video', value: 'Video' },
-      ],
+      // 正準値は ./fields/log-meta。MCP の create_log / update_log も同じ配列から
+      // z.enum を組む。ここで導出しているのでリテラルの二重管理は発生しない。
+      options: LOG_META_OPTIONS.map((value) => ({ label: value, value })),
       admin: { description: '年表に表示する種別ラベル。' },
     },
     { name: 'url', label: '外部リンク', type: 'text', admin: { description: '設定するとタイトルがこの URL へのリンクになります。' } },

--- a/src/lib/mcp/errors/index.ts
+++ b/src/lib/mcp/errors/index.ts
@@ -16,6 +16,11 @@ export class PostNotFoundError extends Error {
   override name = 'PostNotFoundError' as const;
 }
 
+// 指定 id の log(年表の手動エントリ)が見つからない。
+export class LogNotFoundError extends Error {
+  override name = 'LogNotFoundError' as const;
+}
+
 // 指定 id の media が見つからない。thumbnail / image-row cell の両方で使うため、
 // メッセージは呼び出し側が渡す(文言がユースケースごとに異なるため)。
 export class MediaNotFoundError extends Error {
@@ -95,6 +100,7 @@ export const formatPayloadValidationError = (error: ValidationError): string => 
 export type McpToolError =
   | InvalidInputError
   | PostNotFoundError
+  | LogNotFoundError
   | MediaNotFoundError
   | UnsupportedBlockError
   | BodyValidationError

--- a/src/lib/mcp/tools/logs/index.ts
+++ b/src/lib/mcp/tools/logs/index.ts
@@ -120,7 +120,7 @@ export const createLogToolHandlers = (deps: LogToolDeps) => {
         .map((created) => ({ ...toSummary(created), note: 'draft として作成した。年表に載せるには publish_log を呼ぶこと。' }))
         .match(ok, toToolError),
 
-    updateLog: (input: { id: number; title?: string; date?: string; meta?: Log['meta']; url?: string }): Promise<ToolResult> =>
+    updateLog: (input: { id: number; title?: string; date?: string; meta?: Log['meta']; url?: string | null }): Promise<ToolResult> =>
       // date が来ていれば先に検証する。未指定なら検証をスキップして素通しする。
       (input.date === undefined ? okAsync<string | undefined, McpToolError>(undefined) : parseDate(input.date))
         .andThen(() => findLog(input.id))
@@ -132,7 +132,8 @@ export const createLogToolHandlers = (deps: LogToolDeps) => {
               id: input.id,
               draft: true,
               // 指定されたフィールドだけを送る。undefined を混ぜると Payload 側で
-              // 既存値を上書きしうるため、キー自体を落とす。
+              // 既存値を上書きしうるため、キー自体を落とす。url は null を明示的な
+              // 「リンクを外す」として forward する(undefined = 変更なし、null = クリア)。
               data: {
                 ...(input.title === undefined ? {} : { title: input.title }),
                 ...(input.date === undefined ? {} : { date: input.date }),
@@ -145,7 +146,11 @@ export const createLogToolHandlers = (deps: LogToolDeps) => {
             (cause) => new PayloadOperationError('log の更新に失敗しました', { cause }),
           ),
         )
-        .map((updated) => ({ ...toSummary(updated), note: 'draft を更新した。年表への反映は publish_log を呼ぶこと。' }))
+        // toSummary はバージョンの _status をそのまま返すため、公開済みの log を
+        // 更新した直後でも 'draft' に見えてしまう(実際に /log に出ている published
+        // 版はまだ古いまま)。blog の updatePost(src/lib/mcp/tools/index.ts)と同じ形で
+        // status を説明的な文言に上書きし、note も「未公開」と断定しないようにする。
+        .map((updated) => ({ ...toSummary(updated), status: 'draft version saved', note: '変更は draft version として保存済み。公開への反映には publish_log が必要。' }))
         .match(ok, toToolError),
 
     publishLog: (input: { id: number }): Promise<ToolResult> =>
@@ -234,7 +239,7 @@ export const registerLogTools = (server: McpServer, deps: LogToolDeps): void => 
         title: z.string().min(1).optional(),
         date: z.string().optional().describe('YYYY-MM-DD'),
         meta: z.enum(LOG_META_OPTIONS).optional(),
-        url: z.string().url().optional(),
+        url: z.string().url().nullable().optional().describe('省略すると変更なし。null を渡すとリンクを外す(url なしの状態にする)'),
       },
       annotations: { destructiveHint: false },
     },

--- a/src/lib/mcp/tools/logs/index.ts
+++ b/src/lib/mcp/tools/logs/index.ts
@@ -1,16 +1,23 @@
-import { fromPromise } from 'neverthrow';
+import { err as errResult, errAsync, fromPromise, ok as okResult, okAsync } from 'neverthrow';
 import { z } from 'zod';
 
 import { dayjs } from '@utils/dayjs';
+import { createValidator } from '@utils/run-validators';
 
-import { PayloadOperationError } from '../../errors';
+// collection 本体(src/collections/logs.ts)は next/cache を引くのでここからは import
+// できない。正準値は依存ゼロの葉モジュールに置いてある(Task 1)。
+// src/collections に path alias は無く、tsconfig の paths 変更は禁止(CLAUDE.md)なので相対。
+import { LOG_META_OPTIONS } from '../../../../collections/fields/log-meta';
+import { InvalidInputError, LogNotFoundError, PayloadOperationError } from '../../errors';
 import { ok, toToolError } from '../shared/tool-result';
 
+import type { McpToolError } from '../../errors';
 import type { ToolResult } from '../shared/tool-result';
+import type { Validator } from '@utils/run-validators';
 import type { McpServer } from '@modelcontextprotocol/server';
 import type { Log, User } from '@payload-types';
-import type { Payload } from 'payload';
-import type { Where } from 'payload';
+import type { ResultAsync } from 'neverthrow';
+import type { Payload, Where } from 'payload';
 
 // logs は richText を持たないフラットな collection なので、blog/legal が必要とする
 // MarkdownCodec は渡さない。deps は payload と user だけ。
@@ -20,6 +27,23 @@ export type LogToolDeps = {
 };
 
 type LogStatus = 'draft' | 'published' | 'all';
+
+const DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// 1. 形式 — YYYY-MM-DD かどうか。
+const requireDayFormat: Validator<string, McpToolError> = {
+  run: (value) => (DAY_PATTERN.test(value) ? okResult(value) : errResult(new InvalidInputError(`date は YYYY-MM-DD 形式で指定してください。受け取った値: "${value}"`))),
+};
+
+// 2. 実在 — 2026-02-30 のような「形式は合うが存在しない日付」を弾く。dayjs の strict parse
+//    (customParseFormat)はロールオーバーせず invalid として検出する。
+const requireRealDay: Validator<string, McpToolError> = {
+  run: (value) => (dayjs(value, 'YYYY-MM-DD', true).isValid() ? okResult(value) : errResult(new InvalidInputError(`date が存在しない日付です。受け取った値: "${value}"`))),
+};
+
+const validateDate = createValidator([requireDayFormat, requireRealDay]);
+
+const parseDate = (value: string): ResultAsync<string, McpToolError> => validateDate(value).asyncAndThen((valid) => okAsync(valid));
 
 // Payload の date フィールドは ISO タイムスタンプで返る。read は write が受け付ける
 // 正準形(YYYY-MM-DD)に正規化する — でないと list → update の往復で date を素直に
@@ -53,6 +77,14 @@ const resolveStatusWhere = (status: LogStatus): Where | undefined => {
 export const createLogToolHandlers = (deps: LogToolDeps) => {
   const { payload, user } = deps;
 
+  const findLog = (id: number): ResultAsync<Log | null, McpToolError> =>
+    fromPromise(
+      payload.findByID({ collection: 'logs', id, draft: true, disableErrors: true, overrideAccess: false, user, depth: 0 }),
+      (cause) => new PayloadOperationError('log の取得に失敗しました', { cause }),
+    );
+
+  const requireLog = (doc: Log | null): ResultAsync<Log, McpToolError> => (doc === null ? errAsync(new LogNotFoundError('log が見つかりません。list_logs で id を確認してください。')) : okAsync(doc));
+
   return {
     listLogs: (input: { status?: LogStatus; limit?: number }): Promise<ToolResult> =>
       fromPromise(
@@ -69,6 +101,51 @@ export const createLogToolHandlers = (deps: LogToolDeps) => {
         (cause) => new PayloadOperationError('log 一覧の取得に失敗しました', { cause }),
       )
         .map(({ docs }) => docs.map(toSummary))
+        .match(ok, toToolError),
+
+    createLog: (input: { title: string; date: string; meta: Log['meta']; url?: string }): Promise<ToolResult> =>
+      parseDate(input.date)
+        .andThen(() =>
+          fromPromise(
+            payload.create({
+              collection: 'logs',
+              draft: true,
+              data: { title: input.title, date: input.date, meta: input.meta, url: input.url, _status: 'draft' },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の作成に失敗しました', { cause }),
+          ),
+        )
+        .map((created) => ({ ...toSummary(created), note: 'draft として作成した。年表に載せるには publish_log を呼ぶこと。' }))
+        .match(ok, toToolError),
+
+    updateLog: (input: { id: number; title?: string; date?: string; meta?: Log['meta']; url?: string }): Promise<ToolResult> =>
+      // date が来ていれば先に検証する。未指定なら検証をスキップして素通しする。
+      (input.date === undefined ? okAsync<string | undefined, McpToolError>(undefined) : parseDate(input.date))
+        .andThen(() => findLog(input.id))
+        .andThen(requireLog)
+        .andThen(() =>
+          fromPromise(
+            payload.update({
+              collection: 'logs',
+              id: input.id,
+              draft: true,
+              // 指定されたフィールドだけを送る。undefined を混ぜると Payload 側で
+              // 既存値を上書きしうるため、キー自体を落とす。
+              data: {
+                ...(input.title === undefined ? {} : { title: input.title }),
+                ...(input.date === undefined ? {} : { date: input.date }),
+                ...(input.meta === undefined ? {} : { meta: input.meta }),
+                ...(input.url === undefined ? {} : { url: input.url }),
+              },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の更新に失敗しました', { cause }),
+          ),
+        )
+        .map((updated) => ({ ...toSummary(updated), note: 'draft を更新した。年表への反映は publish_log を呼ぶこと。' }))
         .match(ok, toToolError),
   };
 };
@@ -88,5 +165,38 @@ export const registerLogTools = (server: McpServer, deps: LogToolDeps): void => 
       annotations: { readOnlyHint: true },
     },
     handlers.listLogs,
+  );
+
+  server.registerTool(
+    'create_log',
+    {
+      title: 'log 作成(draft)',
+      description: '年表の手動エントリを draft として作成する。年表に載せるには publish_log を続けて呼ぶこと。',
+      inputSchema: {
+        title: z.string().min(1).describe('年表に出るテキスト。例: "Booth2Booth vol.03 at VRChat 開催"'),
+        date: z.string().describe('YYYY-MM-DD'),
+        meta: z.enum(LOG_META_OPTIONS).describe('年表に出る種別ラベル。この値がそのまま画面に表示される'),
+        url: z.string().url().optional().describe('設定するとタイトルがこの URL へのリンクになる'),
+      },
+      annotations: { destructiveHint: false },
+    },
+    handlers.createLog,
+  );
+
+  server.registerTool(
+    'update_log',
+    {
+      title: 'log 更新(draft)',
+      description: 'log を更新する。指定したフィールドだけが変わる。年表への反映は publish_log を呼ぶこと。',
+      inputSchema: {
+        id: z.number().int(),
+        title: z.string().min(1).optional(),
+        date: z.string().optional().describe('YYYY-MM-DD'),
+        meta: z.enum(LOG_META_OPTIONS).optional(),
+        url: z.string().url().optional(),
+      },
+      annotations: { destructiveHint: false },
+    },
+    handlers.updateLog,
   );
 };

--- a/src/lib/mcp/tools/logs/index.ts
+++ b/src/lib/mcp/tools/logs/index.ts
@@ -1,0 +1,92 @@
+import { fromPromise } from 'neverthrow';
+import { z } from 'zod';
+
+import { dayjs } from '@utils/dayjs';
+
+import { PayloadOperationError } from '../../errors';
+import { ok, toToolError } from '../shared/tool-result';
+
+import type { ToolResult } from '../shared/tool-result';
+import type { McpServer } from '@modelcontextprotocol/server';
+import type { Log, User } from '@payload-types';
+import type { Payload } from 'payload';
+import type { Where } from 'payload';
+
+// logs は richText を持たないフラットな collection なので、blog/legal が必要とする
+// MarkdownCodec は渡さない。deps は payload と user だけ。
+export type LogToolDeps = {
+  payload: Payload;
+  user: User;
+};
+
+type LogStatus = 'draft' | 'published' | 'all';
+
+// Payload の date フィールドは ISO タイムスタンプで返る。read は write が受け付ける
+// 正準形(YYYY-MM-DD)に正規化する — でないと list → update の往復で date を素直に
+// 渡し戻したときに弾かれる(read-normalize / write-strict)。
+// dayOnly の値は UTC インスタントなので、JST 暦日で切らないと 1 日ズレる
+// (.claude/rules/dayjs-timezone.md)。
+const toSummary = (doc: Log) => ({
+  id: doc.id,
+  title: doc.title,
+  date: dayjs(doc.date).tz('Asia/Tokyo').format('YYYY-MM-DD'),
+  meta: doc.meta,
+  url: doc.url ?? null,
+  status: doc._status ?? 'draft',
+});
+
+const resolveStatusWhere = (status: LogStatus): Where | undefined => {
+  switch (status) {
+    case 'all':
+      return undefined;
+    case 'draft':
+      return { _status: { equals: 'draft' } };
+    case 'published':
+      return { _status: { equals: 'published' } };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`unhandled log status: ${`${_exhaustive}`}`);
+    }
+  }
+};
+
+export const createLogToolHandlers = (deps: LogToolDeps) => {
+  const { payload, user } = deps;
+
+  return {
+    listLogs: (input: { status?: LogStatus; limit?: number }): Promise<ToolResult> =>
+      fromPromise(
+        payload.find({
+          collection: 'logs',
+          draft: true,
+          where: resolveStatusWhere(input.status ?? 'all'),
+          limit: input.limit ?? 0,
+          sort: '-date',
+          overrideAccess: false,
+          user,
+          depth: 0,
+        }),
+        (cause) => new PayloadOperationError('log 一覧の取得に失敗しました', { cause }),
+      )
+        .map(({ docs }) => docs.map(toSummary))
+        .match(ok, toToolError),
+  };
+};
+
+export const registerLogTools = (server: McpServer, deps: LogToolDeps): void => {
+  const handlers = createLogToolHandlers(deps);
+
+  server.registerTool(
+    'list_logs',
+    {
+      title: 'log 一覧',
+      description: '/log の年表に載る手動エントリを一覧する。id / title / date / meta / url / 公開状態を返す。update_log・publish_log・delete_log に渡す id はここで確認する。',
+      inputSchema: {
+        status: z.enum(['draft', 'published', 'all']).optional().describe('既定は all'),
+        limit: z.number().int().positive().optional().describe('既定は無制限'),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    handlers.listLogs,
+  );
+};

--- a/src/lib/mcp/tools/logs/index.ts
+++ b/src/lib/mcp/tools/logs/index.ts
@@ -147,6 +147,47 @@ export const createLogToolHandlers = (deps: LogToolDeps) => {
         )
         .map((updated) => ({ ...toSummary(updated), note: 'draft を更新した。年表への反映は publish_log を呼ぶこと。' }))
         .match(ok, toToolError),
+
+    publishLog: (input: { id: number }): Promise<ToolResult> =>
+      findLog(input.id)
+        .andThen(requireLog)
+        // draft-promotion: versions.drafts が有効なため update_log の変更は versions
+        // テーブルに積まれる。ここで bare `_status` だけを update すると published 済みの
+        // main テーブル行の上に浅くマージされ、未公開の draft 編集が黙って失われる。
+        // 最新 draft を読み直し、全フィールドを published 付きで再送する
+        // (blog の publishPost と同じ形、src/lib/mcp/tools/index.ts)。
+        .andThen((current) =>
+          fromPromise(
+            payload.update({
+              collection: 'logs',
+              id: input.id,
+              data: {
+                title: current.title,
+                date: current.date,
+                meta: current.meta,
+                url: current.url,
+                _status: 'published',
+              },
+              overrideAccess: false,
+              user,
+            }),
+            (cause) => new PayloadOperationError('log の公開に失敗しました', { cause }),
+          ),
+        )
+        .map((published) => ({ ...toSummary(published), note: '公開した。/log の年表に反映される。' }))
+        .match(ok, toToolError),
+
+    deleteLog: (input: { id: number }): Promise<ToolResult> =>
+      // 削除前に実物を引くのは ①存在しない id を回復ヒントで弾く ②何を消したかを
+      // 応答に含める、の 2 つのため。Payload の delete はバージョンごと消すハード削除で
+      // 復元手段がない。
+      findLog(input.id)
+        .andThen(requireLog)
+        .andThen((doc) =>
+          fromPromise(payload.delete({ collection: 'logs', id: input.id, overrideAccess: false, user }), (cause) => new PayloadOperationError('log の削除に失敗しました', { cause })).map(() => doc),
+        )
+        .map((deleted) => ({ ...toSummary(deleted), note: '削除した。復元はできない。' }))
+        .match(ok, toToolError),
   };
 };
 
@@ -198,5 +239,27 @@ export const registerLogTools = (server: McpServer, deps: LogToolDeps): void => 
       annotations: { destructiveHint: false },
     },
     handlers.updateLog,
+  );
+
+  server.registerTool(
+    'publish_log',
+    {
+      title: 'log 公開',
+      description: 'log を公開して /log の年表に載せる。最新 draft の内容がそのまま公開される。',
+      inputSchema: { id: z.number().int() },
+      annotations: { destructiveHint: false },
+    },
+    handlers.publishLog,
+  );
+
+  server.registerTool(
+    'delete_log',
+    {
+      title: 'log 削除',
+      description: 'log を削除する。復元はできない。削除前に list_logs で対象の id を必ず確認すること。',
+      inputSchema: { id: z.number().int() },
+      annotations: { destructiveHint: true },
+    },
+    handlers.deleteLog,
   );
 };

--- a/src/lib/mcp/tools/logs/logs.test.ts
+++ b/src/lib/mcp/tools/logs/logs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createLogToolHandlers } from '.';
+
+import type { LogToolDeps } from '.';
+import type { User } from '@payload-types';
+
+const user = { id: 1, email: 'dev@napochaan.com' } as User;
+
+const createDeps = () => {
+  const payload = {
+    find: vi.fn(),
+    findByID: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  const deps = { payload, user } as unknown as LogToolDeps;
+
+  return { payload, deps };
+};
+
+describe('listLogs', () => {
+  it('published だけを引く where を組む', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({ docs: [] });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.listLogs({ status: 'published' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        draft: true,
+        where: { _status: { equals: 'published' } },
+        sort: '-date',
+        overrideAccess: false,
+        user,
+      }),
+    );
+  });
+
+  it('status 未指定なら all 扱いで where を付けない', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({ docs: [] });
+
+    const handlers = createLogToolHandlers(deps);
+    await handlers.listLogs({});
+
+    expect(payload.find).toHaveBeenCalledWith(expect.objectContaining({ where: undefined }));
+  });
+
+  it('date を JST 暦日の YYYY-MM-DD に正規化して返す', async () => {
+    const { payload, deps } = createDeps();
+    payload.find.mockResolvedValue({
+      docs: [{ id: 7, title: 'TBA at Real に VJ 出演', date: '2026-10-24T00:00:00.000Z', meta: 'VJ', url: null, _status: 'published' }],
+    });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.listLogs({});
+
+    expect(JSON.parse(result.content[0]?.text ?? '')).toEqual([{ id: 7, title: 'TBA at Real に VJ 出演', date: '2026-10-24', meta: 'VJ', url: null, status: 'published' }]);
+  });
+});

--- a/src/lib/mcp/tools/logs/logs.test.ts
+++ b/src/lib/mcp/tools/logs/logs.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
-import { createLogToolHandlers } from '.';
+import { LOG_META_OPTIONS } from '../../../../collections/fields/log-meta';
+
+import { createLogToolHandlers, registerLogTools } from '.';
 
 import type { LogToolDeps } from '.';
+import type { McpServer } from '@modelcontextprotocol/server';
 import type { User } from '@payload-types';
 
 const user = { id: 1, email: 'dev@napochaan.com' } as User;
@@ -120,6 +124,18 @@ describe('updateLog', () => {
     expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, data: { title: '新' } }));
   });
 
+  it('url: null を渡すとリンクをクリアする', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '旧', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: 'https://example.com', _status: 'draft' });
+    payload.update.mockResolvedValue({ id: 9, title: '旧', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 9, url: null });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, data: { url: null } }));
+  });
+
   it('存在しない id は回復ヒント付きで reject し、update しない', async () => {
     const { payload, deps } = createDeps();
     payload.findByID.mockResolvedValue(null);
@@ -130,6 +146,53 @@ describe('updateLog', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text ?? '').toContain('list_logs');
     expect(payload.update).not.toHaveBeenCalled();
+  });
+
+  // toSummary はバージョンの _status をそのまま返すため、公開済みの log を更新した直後
+  // でも 'draft' に見えてしまう(実際の /log にはまだ古い published 内容が出ている)。
+  // blog の updatePost と同じ形で status を説明的な文言に上書きする(Fix 2)。
+  it('公開済み log を更新しても status は draft と断定せず説明的な文言を返す', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '旧', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'published' });
+    payload.update.mockResolvedValue({ id: 9, title: '新', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 9, title: '新' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]?.text ?? '');
+    expect(parsed.status).toBe('draft version saved');
+    expect(parsed.note).not.toContain('未公開');
+    expect(parsed.note).not.toContain('年表への反映は');
+  });
+});
+
+describe('registerLogTools - meta スキーマ', () => {
+  // meta の不正値の弾き込みは今は MCP SDK の JSON Schema バリデータが enum を
+  // 列挙していることに依存している。ハンドラ内の `meta: Log['meta']` は
+  // コンパイル時の型に過ぎず、もし誰かが inputSchema を z.string() に緩めても
+  // 気づけない(mcp-write-strict.md が言う「Payload に到達する前に弾く」対象)。
+  // registerTool に渡された実際の zod スキーマを捕まえて直接検証する。
+  it('create_log の meta スキーマは LOG_META_OPTIONS の 8 値のみ受理する', () => {
+    const { deps } = createDeps();
+    const captured: { inputSchema?: Record<string, z.ZodTypeAny> } = {};
+    const server = {
+      registerTool: (name: string, config: { inputSchema?: Record<string, z.ZodTypeAny> }) => {
+        if (name === 'create_log') {
+          captured.inputSchema = config.inputSchema;
+        }
+      },
+    } as unknown as McpServer;
+
+    registerLogTools(server, deps);
+
+    const metaSchema = captured.inputSchema?.meta;
+    if (metaSchema === undefined) throw new Error('create_log の inputSchema.meta が捕まえられなかった');
+
+    for (const value of LOG_META_OPTIONS) {
+      expect(metaSchema.safeParse(value).success).toBe(true);
+    }
+    expect(metaSchema.safeParse('存在しないラベル').success).toBe(false);
   });
 });
 

--- a/src/lib/mcp/tools/logs/logs.test.ts
+++ b/src/lib/mcp/tools/logs/logs.test.ts
@@ -132,3 +132,65 @@ describe('updateLog', () => {
     expect(payload.update).not.toHaveBeenCalled();
   });
 });
+
+describe('publishLog', () => {
+  // draft-promotion: versions.drafts が有効なため update_log の変更は versions テーブルに
+  // 積まれる。bare `_status` だけを update すると published 済みの main テーブル行の上に
+  // 浅くマージされ、未公開の draft 編集が黙って失われる(blog の publishPost と同じ罠)。
+  it('最新 draft の全フィールドを published で再送する', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'draft' });
+    payload.update.mockResolvedValue({ id: 9, title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'published' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.publishLog({ id: 9 });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        id: 9,
+        data: { title: '最新draft', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: 'https://example.com', _status: 'published' },
+      }),
+    );
+  });
+
+  it('存在しない id は reject し、update しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.publishLog({ id: 999 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteLog', () => {
+  it('存在する id を削除する', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '消す対象', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+    payload.delete.mockResolvedValue({ id: 9 });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.deleteLog({ id: 9 });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.delete).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, overrideAccess: false, user }));
+    expect(JSON.parse(result.content[0]?.text ?? '')).toEqual(expect.objectContaining({ id: 9, title: '消す対象' }));
+  });
+
+  it('存在しない id は回復ヒント付きで reject し、delete しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.deleteLog({ id: 999 });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
+    expect(payload.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/mcp/tools/logs/logs.test.ts
+++ b/src/lib/mcp/tools/logs/logs.test.ts
@@ -63,3 +63,72 @@ describe('listLogs', () => {
     expect(JSON.parse(result.content[0]?.text ?? '')).toEqual([{ id: 7, title: 'TBA at Real に VJ 出演', date: '2026-10-24', meta: 'VJ', url: null, status: 'published' }]);
   });
 });
+
+describe('createLog', () => {
+  it('draft として作成する', async () => {
+    const { payload, deps } = createDeps();
+    payload.create.mockResolvedValue({ id: 9, title: 'Booth2Booth vol.04', date: '2026-11-01T00:00:00.000Z', meta: 'DJ/VJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'Booth2Booth vol.04', date: '2026-11-01', meta: 'DJ/VJ' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'logs',
+        draft: true,
+        overrideAccess: false,
+        user,
+        data: expect.objectContaining({ title: 'Booth2Booth vol.04', date: '2026-11-01', meta: 'DJ/VJ', _status: 'draft' }),
+      }),
+    );
+  });
+
+  it('date の形式が違えば回復ヒント付きで reject し、create しない', async () => {
+    const { payload, deps } = createDeps();
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'x', date: '2026/11/01', meta: 'DJ' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? '').toContain('YYYY-MM-DD');
+    expect(result.content[0]?.text ?? '').toContain('2026/11/01');
+    expect(payload.create).not.toHaveBeenCalled();
+  });
+
+  it('存在しない日付は reject する', async () => {
+    const { payload, deps } = createDeps();
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.createLog({ title: 'x', date: '2026-02-30', meta: 'DJ' });
+
+    expect(result.isError).toBe(true);
+    expect(payload.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateLog', () => {
+  it('指定したフィールドだけを渡す', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue({ id: 9, title: '旧', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+    payload.update.mockResolvedValue({ id: 9, title: '新', date: '2026-11-01T00:00:00.000Z', meta: 'DJ', url: null, _status: 'draft' });
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 9, title: '新' });
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.update).toHaveBeenCalledWith(expect.objectContaining({ collection: 'logs', id: 9, data: { title: '新' } }));
+  });
+
+  it('存在しない id は回復ヒント付きで reject し、update しない', async () => {
+    const { payload, deps } = createDeps();
+    payload.findByID.mockResolvedValue(null);
+
+    const handlers = createLogToolHandlers(deps);
+    const result = await handlers.updateLog({ id: 999, title: '新' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text ?? '').toContain('list_logs');
+    expect(payload.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`/log` の年表に載る手動エントリ(`logs` collection)を MCP から追加・編集・公開・削除できるようにする。

## ツール(5 つ)

| ツール | 引数 | 用途 |
| --- | --- | --- |
| `list_logs` | `status?`(draft/published/all), `limit?` | id を得る唯一の手段 |
| `create_log` | `title`, `date`, `meta`, `url?` | **draft** で作成 |
| `update_log` | `id` + 変えたいフィールドのみ | `url: null` でリンクを外せる |
| `publish_log` | `id` | 年表に載せる(draft-promotion) |
| `delete_log` | `id` | ハード削除 |

`logs` は既存の MCP 対象 2 コレクションと性格が違う。slug が無く(識別は `id` のみ)、richText も無い 4 フィールドのフラットな collection なので、blog/legal が必要としている Markdown codec 層(image-ref パーサ、block フェンス検証、署名付きアップロード)は**丸ごと不要**。`LogToolDeps` は `{ payload, user }` だけ。

## 設計判断

### `meta` の正準値を依存ゼロの葉モジュールに置く

`meta` の値は**そのまま年表の表示ラベルになる**うえ、既存 DB 行とバイト一致していないと壊れる。`src/collections/fields/log-meta` を単一の出所とし、collection の `options` も MCP の `z.enum` もそこから**導出**する。

collection 本体(`src/collections/logs.ts`)から export しなかったのは、それが `./hooks/revalidate` 経由で `next/cache` を先頭 import しており、MCP ツールや node 環境の vitest から import できないため。`src/collections/fields/slug/` が同じ用途の既存パターン。

導出しているので二重管理は構造上発生せず、同期テストは不要。代わりに `satisfies readonly Log['meta'][]` で `payload-types.ts` とのズレをコンパイル時に検出し、リテラル 8 個そのものはコロケートしたテストで固定する(`'DJ/VJ'` を `'DJ / VJ'` に直すと既存行と不一致になるが、`Log['meta']` も同時に再生成されるため型では守れない)。

### `create` は draft、公開は別操作

`create_log` は必ず `_status: 'draft'` で作り、`publish_log` で公開する 2 段階(blog と同形)。log は 4 フィールドの事実データだが、公開の意思決定を明示的な操作として残す。

### `publish_log` は draft-promotion

`logs` は `versions.drafts` が有効なので `update_log` の変更は versions テーブルに積まれる。bare `_status` だけを update すると published 済みの main テーブル行の上に浅くマージされ、**未公開の draft 編集が黙って失われる**。最新 draft を読み直して 4 フィールド全てを `_status: 'published'` 付きで再送する(blog の `publishPost` と同じ)。

### `delete_log` は `id` のみ

当初案では誤爆防止に `title` の完全一致を必須にしていたが、`id` だけで弾く形を採用した。

**受容したトレードオフ**: LLM が「存在するが別の」 id を掴んだ場合、サーバー側で止める手段はない。残る抑止は `annotations: { destructiveHint: true }` によるクライアント側の確認 UI のみで、これを尊重するかはクライアント実装に依存する。Payload の `delete()` はバージョンテーブルごと消すハード削除で復元手段はない。

### 日付は必ず `@utils/dayjs` を通す

`date` は `dayOnly` フィールドで、値は UTC インスタントとして返る。JST で素朴に slice すると 1 日ズレる(legal の `effectiveAt` で実際に起きた事故)。`YYYY-MM-DD` 固定で受け、形式と実在の 2 段で strict 検証する(`2026-02-30` のような存在しない日付を dayjs の strict parse で弾く)。

読みは write が受け付ける正準形に正規化して返すので、`list_logs` → `update_log` の往復が安定する。

### ISR は追加実装なし

`logs.ts` の `afterChange` / `afterDelete` フックが既に `/` と `/log` を revalidate するため、delete も含めて自動反映される。

## レビューで直したもの

- **`url` を設定できるが消せなかった**: `z.string().url().optional()` には「空にする値」がなく、条件付きスプレッドが `undefined` を落とすため、一度付けた外部リンクを外せなかった。実 DB 36 行中 4 行が `url = NULL` = 「リンクなし」は実在する状態。`update_log` の `url` を `.nullable()` にして `null` で消せるようにした(`create_log` は省略すれば済むので据え置き)。
- **`update_log` が公開中エントリに `status: "draft"` を返していた**: `toSummary` はバージョンの `_status` を返すため、公開済み log を編集すると「まだ公開されていない」と誤読される。blog の `updatePost` と同じ `status: 'draft version saved'` という記述的文言に揃えた。

## 検証

- `pnpm test` 1499 pass / 1 skip / 0 fail(`main` 時点 1482 → **+17 は全て新規テスト**)
- `pnpm lint` / `pnpm typecheck` / `pnpm build` すべて clean
- ツール 5 つの登録と、`meta` リテラルが正準値以外に複製されていないことを確認

## 残件(リリースゲート)

**Payload の draft 部分更新の実挙動が未検証。** レビューが Payload のソースを追って「`update_log({id, title})` が `date`/`meta` を NULL にした疎な draft version を書く可能性がある」と指摘した。実在すれば `publish_log` が必須項目エラーで落ちる。

ただし読み違いの可能性が高いと本人も述べている — **blog の `updatePost`/`publishPost` が同一の形で staging E2E を通過している**ため。決定的なのは、リポジトリのテストが全て payload をモックしており、**ソースを読むだけでは決着しない**点。

マージ後の staging E2E で 3 回の呼び出しにより決着させる:

```
create_log → title だけの update_log → list_logs
  date と meta が生き残っていれば杞憂
  消えていれば logs と blog の両方で Critical(fix は update_log も全フィールド再送にする)
```

## ドキュメント

- `docs/superpowers/specs/2026-08-18-logs-mcp-tools-design.md` — 設計と決定の根拠
- `docs/superpowers/plans/2026-08-18-logs-mcp-tools.md` — 実装計画

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT4nqdBLcsC482v6PTuo6s