### PR TITLE
ci: add job timeouts and retry the playwright chromium install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   quality:
     name: lint & typecheck
     runs-on: ubuntu-latest
+    # 実績は 40s 前後。ジョブ既定の 360 分だと、ネットワーク起因のハングを
+    # 6 時間放置して runner を占有し続ける。
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -28,10 +31,28 @@ jobs:
   test:
     name: vitest (browser + unit + workers)
     runs-on: ubuntu-latest
+    # 実績は 1m30s 前後(chromium のダウンロード込み)。
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       # The `browser` vitest project drives headless chromium via Playwright.
+      #
+      # `timeout` でラップしているのは、このステップが 2026-08-19 に 2 回連続で
+      # ハングしたため(1 回目 25 分、再実行後も 10 分以上、いずれも `pnpm test` に
+      # 到達せず)。ハングは exit code を返さないのでリトライループでは拾えない —
+      # `timeout` で失敗に変換して初めて次の試行に進める。
+      # step の timeout-minutes は全リトライを含む上限なので、5 分 × 3 回 + 待ちを賄う値にする。
       - name: Install Playwright chromium
-        run: pnpm exec playwright install --with-deps chromium
+        timeout-minutes: 18
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 pnpm exec playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::playwright install attempt ${attempt} failed or timed out"
+            sleep 15
+          done
+          echo "::error::playwright install failed after 3 attempts"
+          exit 1
       - run: pnpm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ jobs:
     if: github.event_name == 'push'
     name: deploy staging
     runs-on: ubuntu-latest
+    # 実績は 4 分前後。ジョブ既定の 360 分だと、ハングしたデプロイが
+    # concurrency group を掴んだまま後続を止め続ける。
+    timeout-minutes: 30
     environment: staging
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -38,6 +41,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     name: deploy production
     runs-on: ubuntu-latest
+    # timeout-minutes は意図的に付けていない。required reviewers の承認待ち時間が
+    # ジョブのタイムアウトに算入されるかを確認できておらず、算入されるなら
+    # 「承認待ちのまま自動キャンセル」になってしまうため。
+    # 承認ゲートの無い staging では付けている。挙動を確認できたらここにも入れること。
     # Environment 保護ルール（required reviewers）でデプロイ前に承認を要求する
     environment: production
     env:


### PR DESCRIPTION
CI と Deploy のどのジョブにも `timeout-minutes` が無く、GitHub 既定の **360 分**が効いていた。ネットワーク起因のハングを 6 時間放置して runner を占有し続ける設定になっている。

## きっかけ

2026-08-19、PR #42 の CI で **`Install Playwright chromium` が 2 回連続ハング**した。

```
1 回目: 25 分経過してもステップ 4 のまま(pnpm test は未開始) → cancel
再実行: 10 分以上経過しても同じステップ
```

止まっていたのは依存のダウンロードで、テストは 1 行も走っていない。ローカルでは同じスイートが 9 秒で完走し、PR #41 では同じステップが 1 分半で通っていたので、原因はコード側ではなく chromium の取得経路。

## 変更

| ジョブ | timeout | 実績 |
| --- | --- | --- |
| CI / quality (lint & typecheck) | 10 分 | 約 40 秒 |
| CI / test (vitest) | 20 分 | 約 1 分 30 秒 |
| Deploy / staging | 30 分 | 約 4 分 |
| Deploy / production | **付けない** | — |

### playwright install にリトライを入れる

```bash
for attempt in 1 2 3; do
  if timeout 300 pnpm exec playwright install --with-deps chromium; then
    exit 0
  fi
  echo "::warning::playwright install attempt ${attempt} failed or timed out"
  sleep 15
done
```

`timeout 300` でラップしているのが要点。**ハングは exit code を返さないので、素のリトライループでは拾えない。** timeout で失敗に変換して初めて次の試行に進める。ステップ側の `timeout-minutes: 18` は全リトライを含む上限。

### production に付けなかった理由

`environment: production` は required reviewers による承認ゲートを持つ。**その承認待ち時間がジョブのタイムアウトに算入されるかを確認できていない。** 算入されるなら「承認待ちのまま自動キャンセル」になり、今より悪くなる。

ドキュメントで確定できなかったので、推測で入れるより外しておくほうが安全と判断した。承認ゲートの無い staging には入れてある。挙動を確認できたら production にも入れる旨を workflow 内のコメントに残した。

## 検証

- 両ワークフローを YAML としてパースし、`timeout-minutes` が意図どおり設定されていることを確認
- 変更は `timeout-minutes` の追加とリトライループのみ。GitHub の context 式(`github.event.*` 等)は一切使っていないので workflow injection の懸念はない(ループ内の `${attempt}` はシェルのローカル変数)
- この PR 自体の CI 実行が、リトライの動作確認を兼ねる

## 補足

この変更は PR #42 のハングを**直すものではない**。ハングの原因は上流側にあり、ここで入れているのは「ハングしたときに 6 時間ではなく 20 分で失敗する」ことと「一過性なら自動で回復する」ことの 2 点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT4nqdBLcsC482v6PTuo6s